### PR TITLE
Add test against a bug in KokkosKernels batched eigendecomposition

### DIFF
--- a/unit_test/tstBatchedLinearAlgebra.hpp
+++ b/unit_test/tstBatchedLinearAlgebra.hpp
@@ -711,7 +711,6 @@ void kernelTest()
 }
 
 //---------------------------------------------------------------------------//
-/*
 void eigendecompositionTest()
 {
     LinearAlgebra::Matrix<double, 4, 4> A = {
@@ -822,7 +821,6 @@ void eigendecompositionTest()
         for ( int j = 0; j < 4; ++j )
             EXPECT_FLOAT_EQ( A( i, j ), l_op_ident( i, j ) );
 }
-*/
 
 //---------------------------------------------------------------------------//
 // RUN TESTS
@@ -867,8 +865,7 @@ TEST( TEST_CATEGORY, kernelTest )
     kernelTest<20>();
 }
 
-// FIXME_KOKKOSKERNELS
-// TEST( TEST_CATEGORY, eigendecomposition_test ) { eigendecompositionTest(); }
+TEST( TEST_CATEGORY, eigendecomposition_test ) { eigendecompositionTest(); }
 
 //---------------------------------------------------------------------------//
 


### PR DESCRIPTION
Currently, batched serial eigendecomposition is commented out in KokkosKernels. When the KokkosKernels code is uncommented, the existing Picasso test passes. This PR tests a matrix for which the uncommented code path gives incorrect results.

This cannot be merged until it is fixed upstream: kokkos/kokkos-kernels#873.