### PR TITLE
Curvilinear Mesh Interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ set(HEADERS
   Picasso_AdaptiveMesh.hpp
   Picasso_APIC.hpp
   Picasso_BatchedLinearAlgebra.hpp
+  Picasso_BilinearMeshMapping.hpp
+  Picasso_CurvilinearMesh.hpp
   Picasso_FacetGeometry.hpp
   Picasso_FieldManager.hpp
   Picasso_FieldTypes.hpp
@@ -21,6 +23,7 @@ set(HEADERS
   Picasso_PolyPIC.hpp
   Picasso_Types.hpp
   Picasso_UniformMesh.hpp
+  Picasso_UniformCartesianMeshMapping.hpp
   Picasso_Version.hpp
   )
 

--- a/src/Picasso_AdaptiveMesh.hpp
+++ b/src/Picasso_AdaptiveMesh.hpp
@@ -42,6 +42,8 @@ class AdaptiveMesh
     using node_array = Cajita::Array<double, Cajita::Node,
                                      Cajita::UniformMesh<double>, MemorySpace>;
 
+    static constexpr std::size_t num_space_dim = 3;
+
     // Construct an adaptive mesh from the problem bounding box and a property
     // tree.
     template <class ExecutionSpace>

--- a/src/Picasso_BatchedLinearAlgebra.hpp
+++ b/src/Picasso_BatchedLinearAlgebra.hpp
@@ -1499,18 +1499,19 @@ KOKKOS_INLINE_FUNCTION
 //---------------------------------------------------------------------------//
 // Matrix inverse.
 //---------------------------------------------------------------------------//
-// 2x2 specialization.
+// 2x2 specialization with determinant given.
 template <class ExpressionA>
 KOKKOS_INLINE_FUNCTION
     typename std::enable_if_t<is_matrix<ExpressionA>::value &&
                                   ExpressionA::extent_0 == 2 &&
                                   ExpressionA::extent_1 == 2,
                               typename ExpressionA::copy_type>
-    inverse( const ExpressionA& a )
+    inverse( const ExpressionA& a,
+             const typename ExpressionA::value_type a_det )
 {
     typename ExpressionA::eval_type a_eval = a;
 
-    auto a_det_inv = 1.0 / !a_eval;
+    auto a_det_inv = 1.0 / a_det;
 
     Matrix<typename ExpressionA::value_type, 2, 2> a_inv;
 
@@ -1523,18 +1524,33 @@ KOKKOS_INLINE_FUNCTION
 }
 
 //---------------------------------------------------------------------------//
-// 3x3 specialization.
+// 2x2 specialization.
+template <class ExpressionA>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if_t<is_matrix<ExpressionA>::value &&
+                                  ExpressionA::extent_0 == 2 &&
+                                  ExpressionA::extent_1 == 2,
+                              typename ExpressionA::copy_type>
+    inverse( const ExpressionA& a )
+{
+    typename ExpressionA::eval_type a_eval = a;
+    return inverse( a_eval, !a_eval );
+}
+
+//---------------------------------------------------------------------------//
+// 3x3 specialization with determinant given.
 template <class ExpressionA>
 KOKKOS_INLINE_FUNCTION
     typename std::enable_if_t<is_matrix<ExpressionA>::value &&
                                   ExpressionA::extent_0 == 3 &&
                                   ExpressionA::extent_1 == 3,
                               typename ExpressionA::copy_type>
-    inverse( const ExpressionA& a )
+    inverse( const ExpressionA& a,
+             const typename ExpressionA::value_type a_det )
 {
     typename ExpressionA::eval_type a_eval = a;
 
-    auto a_det_inv = 1.0 / !a_eval;
+    auto a_det_inv = 1.0 / a_det;
 
     Matrix<typename ExpressionA::value_type, 3, 3> a_inv;
 
@@ -1569,6 +1585,20 @@ KOKKOS_INLINE_FUNCTION
         a_det_inv;
 
     return a_inv;
+}
+
+//---------------------------------------------------------------------------//
+// 3x3 specialization.
+template <class ExpressionA>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if_t<is_matrix<ExpressionA>::value &&
+                                  ExpressionA::extent_0 == 3 &&
+                                  ExpressionA::extent_1 == 3,
+                              typename ExpressionA::copy_type>
+    inverse( const ExpressionA& a )
+{
+    typename ExpressionA::eval_type a_eval = a;
+    return inverse( a_eval, !a_eval );
 }
 
 //---------------------------------------------------------------------------//

--- a/src/Picasso_BilinearMeshMapping.hpp
+++ b/src/Picasso_BilinearMeshMapping.hpp
@@ -1,0 +1,534 @@
+/****************************************************************************
+ * Copyright (c) 2021 by the Picasso authors                                *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Picasso library. Picasso is distributed under a *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef PICASSO_BILINEARMESHMAPPING_HPP
+#define PICASSO_BILINEARMESHMAPPING_HPP
+
+#include <Picasso_BatchedLinearAlgebra.hpp>
+#include <Picasso_CurvilinearMesh.hpp>
+#include <Picasso_FieldManager.hpp>
+#include <Picasso_Types.hpp>
+
+#include <Cajita.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <mpi.h>
+
+#include <limits>
+#include <type_traits>
+
+namespace Picasso
+{
+//---------------------------------------------------------------------------//
+/*!
+  \class BilinearMeshMapping
+  \brief Bilinear mesh mapping function.
+
+  All cells in the mesh are described by physical node locations and a linear
+  polynomial basis representing the space continuum between them.
+ */
+template <class MemorySpace, std::size_t NumSpaceDim>
+struct BilinearMeshMapping
+{
+    using memory_space = MemorySpace;
+
+    static constexpr std::size_t num_space_dim = NumSpaceDim;
+
+    using mesh_type =
+        CurvilinearMesh<BilinearMeshMapping<MemorySpace, NumSpaceDim>>;
+
+    using coord_view_type = std::conditional_t<
+        3 == num_space_dim, Kokkos::View<double****, MemorySpace>,
+        std::conditional_t<2 == num_space_dim,
+                           Kokkos::View<double***, MemorySpace>, void>>;
+
+    // Construct a bilinear mapping.
+    BilinearMeshMapping( const Kokkos::Array<int, NumSpaceDim>& global_num_cell,
+                         const Kokkos::Array<bool, NumSpaceDim>& periodic )
+        : _global_num_cell( global_num_cell )
+        , _periodic( periodic )
+    {
+    }
+
+    // Set the local node coordinates including the halo region.
+    void setLocalNodeCoordinates( const coord_view_type& local_node_coords )
+    {
+        _local_node_coords = local_node_coords;
+    }
+
+    Kokkos::Array<int, NumSpaceDim> _global_num_cell;
+    Kokkos::Array<bool, NumSpaceDim> _periodic;
+    Kokkos::Array<int, NumSpaceDim> _global_offset;
+    coord_view_type _local_node_coords;
+};
+
+//---------------------------------------------------------------------------//
+// Template interface implementation. 3D specialization
+template <class MemorySpace>
+class CurvilinearMeshMapping<BilinearMeshMapping<MemorySpace, 3>>
+{
+  public:
+    using memory_space = MemorySpace;
+    using mesh_mapping = BilinearMeshMapping<MemorySpace, 3>;
+    static constexpr std::size_t num_space_dim = 3;
+
+    // Get the global number of cells in given logical dimension that construct
+    // the mapping.
+    static int globalNumCell( const mesh_mapping& mapping, const int dim )
+    {
+        return mapping._global_num_cell[dim];
+    }
+
+    // Get the periodicity of a given logical dimension of the mapping.
+    static bool periodic( const mesh_mapping& mapping, const int dim )
+    {
+        return mapping._periodic[dim];
+    }
+
+    // Forward mapping. Given coordinates in the reference frame compute the
+    // coordinates in the physical frame.
+    template <class ReferenceCoords, class PhysicalCoords>
+    static KOKKOS_INLINE_FUNCTION void
+    mapToPhysicalFrame( const mesh_mapping& mapping,
+                        const ReferenceCoords& reference_coords,
+                        PhysicalCoords& physical_coords )
+    {
+        using value_type = typename ReferenceCoords::value_type;
+
+        int ri = static_cast<int>( reference_coords( Dim::I ) );
+        int rj = static_cast<int>( reference_coords( Dim::J ) );
+        int rk = static_cast<int>( reference_coords( Dim::K ) );
+
+        int i = ri - mapping._global_offset[Dim::I];
+        int j = rj - mapping._global_offset[Dim::J];
+        int k = rk - mapping._global_offset[Dim::K];
+
+        value_type xi = reference_coords( Dim::I ) - ri;
+        value_type xj = reference_coords( Dim::J ) - rj;
+        value_type xk = reference_coords( Dim::K ) - rk;
+
+        value_type w[3][2] = {
+            { 1.0 - xi, xi }, { 1.0 - xj, xj }, { 1.0 - xk, xk } };
+
+        physical_coords = 0.0;
+
+        for ( int ni = 0; ni < 2; ++ni )
+            for ( int nj = 0; nj < 2; ++nj )
+                for ( int nk = 0; nk < 2; ++nk )
+                    for ( int d = 0; d < 3; ++d )
+                        physical_coords( d ) +=
+                            w[Dim::I][ni] * w[Dim::J][nj] * w[Dim::K][nk] *
+                            mapping._local_node_coords( i + ni, j + nj, k + nk,
+                                                        d );
+    }
+
+    // Given coordinates in the reference frame compute the grid
+    // transformation metrics. This is the jacobian of the forward mapping,
+    // its determinant, and inverse.
+    template <class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION void transformationMetrics(
+        const mesh_mapping& mapping, const ReferenceCoords& reference_coords,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type, 3, 3>&
+            jacobian,
+        typename ReferenceCoords::value_type& jacobian_det,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type, 3, 3>&
+            jacobian_inv )
+    {
+        using value_type = typename ReferenceCoords::value_type;
+
+        int ri = static_cast<int>( reference_coords( Dim::I ) );
+        int rj = static_cast<int>( reference_coords( Dim::J ) );
+        int rk = static_cast<int>( reference_coords( Dim::K ) );
+
+        int i = ri - mapping._global_offset[Dim::I];
+        int j = rj - mapping._global_offset[Dim::J];
+        int k = rk - mapping._global_offset[Dim::K];
+
+        value_type xi = reference_coords( Dim::I ) - ri;
+        value_type xj = reference_coords( Dim::J ) - rj;
+        value_type xk = reference_coords( Dim::K ) - rk;
+
+        value_type w[3][2] = {
+            { 1.0 - xi, xi }, { 1.0 - xj, xj }, { 1.0 - xk, xk } };
+        value_type g[3][2] = { { -1.0, 1.0 }, { -1.0, 1.0 }, { -1.0, 1.0 } };
+
+        jacobian = 0.0;
+
+        for ( int ni = 0; ni < 2; ++ni )
+            for ( int nj = 0; nj < 2; ++nj )
+                for ( int nk = 0; nk < 2; ++nk )
+                    for ( int d = 0; d < 3; ++d )
+                    {
+                        jacobian( d, Dim::I ) +=
+                            g[Dim::I][ni] * w[Dim::J][nj] * w[Dim::K][nk] *
+                            mapping._local_node_coords( i + ni, j + nj, k + nk,
+                                                        d );
+
+                        jacobian( d, Dim::J ) +=
+                            w[Dim::I][ni] * g[Dim::J][nj] * w[Dim::K][nk] *
+                            mapping._local_node_coords( i + ni, j + nj, k + nk,
+                                                        d );
+
+                        jacobian( d, Dim::K ) +=
+                            w[Dim::I][ni] * w[Dim::J][nj] * g[Dim::K][nk] *
+                            mapping._local_node_coords( i + ni, j + nj, k + nk,
+                                                        d );
+                    }
+
+        jacobian_det = !jacobian;
+
+        jacobian_inv = LinearAlgebra::inverse( jacobian, jacobian_det );
+    }
+
+    // Reverse mapping. Given coordinates in the physical frame compute the
+    // coordinates in the reference frame. Return whether or not the mapping
+    // succeeded.
+    template <class PhysicalCoords, class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION bool
+    mapToReferenceFrame( const mesh_mapping& mapping,
+                         const PhysicalCoords& physical_coords,
+                         ReferenceCoords& reference_coords )
+    {
+        return DefaultCurvilinearMeshMapping<mesh_mapping>::mapToReferenceFrame(
+            mapping, physical_coords, reference_coords );
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Template interface implementation. 2D specialization
+template <class MemorySpace>
+struct CurvilinearMeshMapping<BilinearMeshMapping<MemorySpace, 2>>
+{
+    using memory_space = MemorySpace;
+    using mesh_mapping = BilinearMeshMapping<MemorySpace, 2>;
+    static constexpr std::size_t num_space_dim = 2;
+
+    // Get the global number of cells in given logical dimension that construct
+    // the mapping.
+    static int globalNumCell( const mesh_mapping& mapping, const int dim )
+    {
+        return mapping._global_num_cell[dim];
+    }
+
+    // Get the periodicity of a given logical dimension of the mapping.
+    static bool periodic( const mesh_mapping& mapping, const int dim )
+    {
+        return mapping._periodic[dim];
+    }
+
+    // Forward mapping. Given coordinates in the reference frame compute the
+    // coordinates in the physical frame.
+    template <class ReferenceCoords, class PhysicalCoords>
+    static KOKKOS_INLINE_FUNCTION void
+    mapToPhysicalFrame( const mesh_mapping& mapping,
+                        const ReferenceCoords& reference_coords,
+                        PhysicalCoords& physical_coords )
+    {
+        using value_type = typename ReferenceCoords::value_type;
+
+        int ri = static_cast<int>( reference_coords( Dim::I ) );
+        int rj = static_cast<int>( reference_coords( Dim::J ) );
+
+        int i = ri - mapping._global_offset[Dim::I];
+        int j = rj - mapping._global_offset[Dim::J];
+
+        value_type xi = reference_coords( Dim::I ) - ri;
+        value_type xj = reference_coords( Dim::J ) - rj;
+
+        value_type w[2][2] = { { 1.0 - xi, xi }, { 1.0 - xj, xj } };
+
+        physical_coords = 0.0;
+
+        for ( int ni = 0; ni < 2; ++ni )
+            for ( int nj = 0; nj < 2; ++nj )
+                for ( int d = 0; d < 2; ++d )
+                    physical_coords( d ) +=
+                        w[Dim::I][ni] * w[Dim::J][nj] *
+                        mapping._local_node_coords( i + ni, j + nj, d );
+    }
+
+    // Given coordinates in the reference frame compute the grid
+    // transformation metrics. This is the jacobian of the forward mapping,
+    // its determinant, and inverse.
+    template <class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION void transformationMetrics(
+        const mesh_mapping& mapping, const ReferenceCoords& reference_coords,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type, 2, 2>&
+            jacobian,
+        typename ReferenceCoords::value_type& jacobian_det,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type, 2, 2>&
+            jacobian_inv )
+    {
+        using value_type = typename ReferenceCoords::value_type;
+
+        int ri = static_cast<int>( reference_coords( Dim::I ) );
+        int rj = static_cast<int>( reference_coords( Dim::J ) );
+
+        int i = ri - mapping._global_offset[Dim::I];
+        int j = rj - mapping._global_offset[Dim::J];
+
+        value_type xi = reference_coords( Dim::I ) - ri;
+        value_type xj = reference_coords( Dim::J ) - rj;
+
+        value_type w[2][2] = { { 1.0 - xi, xi }, { 1.0 - xj, xj } };
+        value_type g[2][2] = { { -1.0, 1.0 }, { -1.0, 1.0 } };
+
+        jacobian = 0.0;
+
+        for ( int ni = 0; ni < 2; ++ni )
+            for ( int nj = 0; nj < 2; ++nj )
+                for ( int d = 0; d < 2; ++d )
+                {
+                    jacobian( d, Dim::I ) +=
+                        g[Dim::I][ni] * w[Dim::J][nj] *
+                        mapping._local_node_coords( i + ni, j + nj, d );
+
+                    jacobian( d, Dim::J ) +=
+                        w[Dim::I][ni] * g[Dim::J][nj] *
+                        mapping._local_node_coords( i + ni, j + nj, d );
+                }
+
+        jacobian_det = !jacobian;
+
+        jacobian_inv = LinearAlgebra::inverse( jacobian, jacobian_det );
+    }
+
+    // Reverse mapping. Given coordinates in the physical frame compute the
+    // coordinates in the reference frame. Return whether or not the mapping
+    // succeeded.
+    template <class PhysicalCoords, class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION bool
+    mapToReferenceFrame( const mesh_mapping& mapping,
+                         const PhysicalCoords& physical_coords,
+                         ReferenceCoords& reference_coords )
+    {
+        // NOTE: I am using the default procedure here but it is possible that
+        // the procedure outlined on page 329 of the 1986 Brackbill FLIP paper
+        // could be more efficient here as it is a direct solve. This default
+        // version could be used if that one fails.
+        return DefaultCurvilinearMeshMapping<mesh_mapping>::mapToReferenceFrame(
+            mapping, physical_coords, reference_coords );
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Bilinear mesh generator template interface.
+template <class Generator>
+struct BilinearMeshGenerator
+{
+    static constexpr std::size_t num_space_dim = Generator::num_space_dim;
+
+    // Get the global number of cell in each logical dimension of the mesh.
+    static Kokkos::Array<int, num_space_dim>
+    globalNumCell( const Generator& generator );
+
+    // Get the peridicity of each logical dimension of the mesh.
+    static Kokkos::Array<bool, num_space_dim>
+    periodic( const Generator& generator );
+
+    // Given the local grid compute populate the local node coordinates.
+    template <class NodeCoordinateArray>
+    static void createLocalNodeCoordinates( const Generator& generator,
+                                            const NodeCoordinateArray& coords );
+};
+
+//---------------------------------------------------------------------------//
+// Create a bilinear mesh using a generator. Creates a mapping, a mesh, a
+// field manager, a coordinate array in the field manager, assigns the
+// coordinate field to the mapping, and populates the coordinates. A field
+// manager containing the mesh is returned.
+template <class MemorySpace, class Generator, std::size_t NumSpaceDim>
+auto createBilinearMesh( MemorySpace, Generator generator, const int halo_width,
+                         MPI_Comm comm,
+                         const std::array<int, NumSpaceDim>& ranks_per_dim )
+{
+    // Create the mapping.
+    auto mapping =
+        std::make_shared<BilinearMeshMapping<MemorySpace, NumSpaceDim>>(
+            BilinearMeshGenerator<Generator>::globalNumCell( generator ),
+            BilinearMeshGenerator<Generator>::periodic( generator ) );
+
+    // Create mesh.
+    auto mesh =
+        createCurvilinearMesh( mapping, halo_width, comm, ranks_per_dim );
+
+    // Add the global offset of the domain decomposition. Include the halo
+    // width so we know where the ghost logical grid starts.
+    for ( std::size_t d = 0; d < NumSpaceDim; ++d )
+        mapping->_global_offset[d] =
+            mesh->localGrid()->globalGrid().globalOffset( d ) - halo_width;
+
+    // Create field manager.
+    auto manager = createFieldManager( mesh );
+
+    // Add a node coordinates field to the manager.
+    manager->add( FieldLocation::Node{}, Field::PhysicalPosition{} );
+
+    // Assign coordinates to the mapping.
+    mapping->setLocalNodeCoordinates(
+        manager->view( FieldLocation::Node{}, Field::PhysicalPosition{} ) );
+
+    // Generate the coordinates.
+    BilinearMeshGenerator<Generator>::createLocalNodeCoordinates(
+        generator, *( manager->array( FieldLocation::Node{},
+                                      Field::PhysicalPosition{} ) ) );
+
+    return manager;
+}
+
+//---------------------------------------------------------------------------//
+// Uniform bilinear mesh generator. Generate a uniform bilinear mesh
+// starting with a global bounding box and a uniform grid.
+template <std::size_t NumSpaceDim>
+struct UniformBilinearMeshGenerator
+{
+    // Uniform cell size.
+    double cell_size;
+
+    // Global bounding box.
+    Kokkos::Array<double, 2 * NumSpaceDim> global_bounding_box;
+
+    // Boundary periodicity.
+    Kokkos::Array<bool, NumSpaceDim> periodic;
+};
+
+template <std::size_t NumSpaceDim>
+struct BilinearMeshGenerator<UniformBilinearMeshGenerator<NumSpaceDim>>
+{
+    using Generator = UniformBilinearMeshGenerator<NumSpaceDim>;
+
+    static constexpr std::size_t num_space_dim = NumSpaceDim;
+
+    // Get the global number of cell in each logical dimension of the mesh.
+    static Kokkos::Array<int, num_space_dim>
+    globalNumCell( const Generator& generator )
+    {
+        Kokkos::Array<int, num_space_dim> global_num_cell;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            global_num_cell[d] =
+                ( generator.global_bounding_box[num_space_dim + d] -
+                  generator.global_bounding_box[d] ) /
+                generator.cell_size;
+        }
+
+        // Because the mesh is uniform check that the domain is evenly
+        // divisible by the cell size in each dimension within round-off
+        // error. This will let us do cheaper math for particle location.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            double extent = global_num_cell[d] * generator.cell_size;
+            if ( std::abs( extent -
+                           ( generator.global_bounding_box[num_space_dim + d] -
+                             generator.global_bounding_box[d] ) ) >
+                 std::numeric_limits<float>::epsilon() )
+                throw std::logic_error(
+                    "Extent not evenly divisible by uniform cell size" );
+        }
+
+        return global_num_cell;
+    }
+
+    // Get the peridicity of each logical dimension of the mesh.
+    static Kokkos::Array<bool, num_space_dim>
+    periodic( const Generator& generator )
+    {
+        return generator.periodic;
+    }
+
+    // Given the local grid compute the local node coordinates. 3D
+    // Specialization.
+    template <class NodeCoordinateArray, std::size_t NSD = NumSpaceDim>
+    static std::enable_if_t<3 == NSD, void>
+    createLocalNodeCoordinates( const Generator& generator,
+                                const NodeCoordinateArray& coords )
+    {
+        // Create nodes on the host.
+        auto coords_h =
+            Kokkos::create_mirror_view( Kokkos::HostSpace(), coords.view() );
+
+        // Create local nodes.
+        auto local_grid = coords.layout()->localGrid();
+        auto local_space = local_grid->indexSpace(
+            Cajita::Ghost(), Cajita::Node(), Cajita::Local() );
+        auto local_mesh =
+            Cajita::createLocalMesh<Kokkos::HostSpace>( *local_grid );
+        for ( int i = local_space.min( Dim::I ); i < local_space.max( Dim::I );
+              ++i )
+            for ( int j = local_space.min( Dim::J );
+                  j < local_space.max( Dim::J ); ++j )
+                for ( int k = local_space.min( Dim::K );
+                      k < local_space.max( Dim::K ); ++k )
+                {
+                    coords_h( i, j, k, Dim::I ) =
+                        generator.global_bounding_box[Dim::I] +
+                        ( local_mesh.lowCorner( Cajita::Ghost(), Dim::I ) +
+                          i ) *
+                            generator.cell_size;
+                    coords_h( i, j, k, Dim::J ) =
+                        generator.global_bounding_box[Dim::J] +
+                        ( local_mesh.lowCorner( Cajita::Ghost(), Dim::J ) +
+                          j ) *
+                            generator.cell_size;
+                    coords_h( i, j, k, Dim::K ) =
+                        generator.global_bounding_box[Dim::K] +
+                        ( local_mesh.lowCorner( Cajita::Ghost(), Dim::K ) +
+                          k ) *
+                            generator.cell_size;
+                }
+
+        // Move nodes to device.
+        Kokkos::deep_copy( coords.view(), coords_h );
+    }
+
+    // Given the local grid compute the local node coordinates. 2D
+    // Specialization.
+    template <class NodeCoordinateArray, std::size_t NSD = NumSpaceDim>
+    static std::enable_if_t<2 == NSD, void>
+    createLocalNodeCoordinates( const Generator& generator,
+                                const NodeCoordinateArray& coords )
+    {
+        // Create nodes on the host.
+        auto coords_h =
+            Kokkos::create_mirror_view( Kokkos::HostSpace(), coords.view() );
+
+        // Create owned nodes.
+        auto local_grid = coords.layout()->localGrid();
+        auto local_space = local_grid->indexSpace(
+            Cajita::Ghost(), Cajita::Node(), Cajita::Local() );
+        auto local_mesh =
+            Cajita::createLocalMesh<Kokkos::HostSpace>( *local_grid );
+        for ( int i = local_space.min( Dim::I ); i < local_space.max( Dim::I );
+              ++i )
+            for ( int j = local_space.min( Dim::J );
+                  j < local_space.max( Dim::J ); ++j )
+            {
+                coords_h( i, j, Dim::I ) =
+                    generator.global_bounding_box[Dim::I] +
+                    ( local_mesh.lowCorner( Cajita::Ghost(), Dim::I ) + i ) *
+                        generator.cell_size;
+                coords_h( i, j, Dim::J ) =
+                    generator.global_bounding_box[Dim::J] +
+                    ( local_mesh.lowCorner( Cajita::Ghost(), Dim::J ) + j ) *
+                        generator.cell_size;
+            }
+
+        // Move nodes to device.
+        Kokkos::deep_copy( coords.view(), coords_h );
+    }
+};
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Picasso
+
+#endif // end PICASSO_BILINEARMESHMAPPING_HPP

--- a/src/Picasso_CurvilinearMesh.hpp
+++ b/src/Picasso_CurvilinearMesh.hpp
@@ -1,0 +1,277 @@
+/****************************************************************************
+ * Copyright (c) 2021 by the Picasso authors                                *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Picasso library. Picasso is distributed under a *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef PICASSO_CURVILINEARMESH_HPP
+#define PICASSO_CURVILINEARMESH_HPP
+
+#include <Picasso_BatchedLinearAlgebra.hpp>
+#include <Picasso_Types.hpp>
+
+#include <Cajita.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <array>
+#include <cmath>
+#include <memory>
+#include <type_traits>
+
+#include <mpi.h>
+
+namespace Picasso
+{
+//---------------------------------------------------------------------------//
+// Curvilinear mesh mapping function template interface. Describes the
+// physical frame and physical-to-reference mapping for a curvilinear mesh.
+//
+// Physical frame - the physical representation in the chosen mapping
+// coordinate system.
+//
+// Reference frame - the logical representation in the grid reference
+// frame. Combined with global mesh information, the mesh mapping
+// implementation can convert this to a logical representation in the global
+// grid reference frame.
+//
+// The global reference frame spans from [0,globalNumCell(dim)] in each
+// dimension. Note that the global reference frame will be padded in
+// non-periodic dimensions by the base halo width when the mesh is constructed
+// to allow for stencil operations outside of the domain. Therefore in
+// practice the global reference frame spans from
+// [-halo_width,globalNumCell(dim)+halo_width] in each dimension.
+//
+template <class Mapping>
+struct CurvilinearMeshMapping
+{
+    // Memory space.
+    using memory_space = typename Mapping::memory_space;
+
+    // Spatial dimension.
+    static constexpr std::size_t num_space_dim = Mapping::num_space_dim;
+
+    // Get the global number of cells in given logical dimension that construct
+    // the mapping.
+    static int globalNumCell( const Mapping& mapping, const int dim );
+
+    // Get the periodicity of a given logical dimension of the mapping.
+    static bool periodic( const Mapping& mapping, const int dim );
+
+    // Forward mapping. Given coordinates in the reference frame compute
+    // the coordinates in the physical frame.
+    template <class ReferenceCoords, class PhysicalCoords>
+    static KOKKOS_INLINE_FUNCTION void
+    mapToPhysicalFrame( const Mapping& mapping,
+                        const ReferenceCoords& reference_coords,
+                        PhysicalCoords& physical_coords );
+
+    // Given coordinates in the reference frame compute the grid
+    // transformation metrics. This is the jacobian of the forward mapping,
+    // its determinant, and inverse.
+    template <class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION void transformationMetrics(
+        const Mapping& mapping, const ReferenceCoords& reference_coords,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type,
+                              num_space_dim, num_space_dim>& jacobian,
+        typename ReferenceCoords::value_type& jacobian_det,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type,
+                              num_space_dim, num_space_dim>& jacobian_inv );
+
+    // Reverse mapping. Given coordinates in the physical frame compute the
+    // coordinates in the reference frame. The data in reference_coords
+    // will be used as the initial guess. Return whether or not the mapping
+    // succeeded.
+    template <class PhysicalCoords, class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION bool
+    mapToReferenceFrame( const Mapping& mapping,
+                         const PhysicalCoords& physical_coords,
+                         ReferenceCoords& reference_coords );
+};
+
+//---------------------------------------------------------------------------//
+// Default implementations for mesh mapping functions.
+template <class Mapping>
+struct DefaultCurvilinearMeshMapping
+{
+    static constexpr std::size_t num_space_dim = Mapping::num_space_dim;
+
+    // NOTE: Automatic differentiation of mapToPhysicalFrame could be used as
+    // a default implementation of the transformation metrics.
+
+    // Reverse mapping. Given coordinates in the physical frame compute the
+    // coordinates in the reference frame. The data in reference_coords
+    // will be used as the initial guess. Return whether or not the mapping
+    // succeeded.
+    template <class PhysicalCoords, class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION bool
+    mapToReferenceFrame( const Mapping& mapping,
+                         const PhysicalCoords& physical_coords,
+                         ReferenceCoords& reference_coords )
+    {
+        using value_type = typename PhysicalCoords::value_type;
+
+        // Newton iteration tolerance.
+        double tol = 1.0e-12;
+        double tol2 = tol * tol;
+
+        // Maximum number of Newton iterations.
+        int max_iter = 15;
+
+        // Iteration data.
+        LinearAlgebra::Vector<value_type, num_space_dim> x_ref_old;
+        LinearAlgebra::Vector<value_type, num_space_dim> x_phys_new;
+        LinearAlgebra::Matrix<value_type, num_space_dim, num_space_dim>
+            jacobian;
+        value_type jacobian_det;
+        LinearAlgebra::Matrix<value_type, num_space_dim, num_space_dim>
+            jacobian_inv;
+
+        // Newton iterations.
+        value_type error;
+        for ( int n = 0; n < max_iter; ++n )
+        {
+
+            // Update iteration.
+            x_ref_old = reference_coords;
+
+            // Compute jacobian.
+            CurvilinearMeshMapping<Mapping>::transformationMetrics(
+                mapping, x_ref_old, jacobian, jacobian_det, jacobian_inv );
+
+            // Compute residual.
+            CurvilinearMeshMapping<Mapping>::mapToPhysicalFrame(
+                mapping, x_ref_old, x_phys_new );
+
+            // Update solution.
+            reference_coords =
+                jacobian_inv * ( physical_coords - x_phys_new ) + x_ref_old;
+
+            // Check for convergence.
+            error = ~( reference_coords - x_ref_old ) *
+                    ( reference_coords - x_ref_old );
+
+            // Return true if we converged.
+            if ( error < tol2 )
+                return true;
+        }
+
+        // Return false if we failed to converge.
+        return false;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+  \class CurvilinearMesh
+  \brief Logically rectilinear curvilinear mesh based on a given mapping.
+ */
+template <class Mapping>
+class CurvilinearMesh
+{
+  public:
+    using mesh_mapping = Mapping;
+
+    using memory_space = typename CurvilinearMeshMapping<Mapping>::memory_space;
+
+    static constexpr std::size_t num_space_dim =
+        CurvilinearMeshMapping<Mapping>::num_space_dim;
+
+    using cajita_mesh = Cajita::UniformMesh<double, num_space_dim>;
+
+    using local_grid = Cajita::LocalGrid<cajita_mesh>;
+
+    /*!
+      \brief Constructor.
+      \param mapping The mapping with which to build the curvilinear mesh.
+      \param halo_width The maximum number of cells required for grid halo
+      operations.
+      \param comm The MPI comm to use for the mesh.
+      \param ranks_per_dim The number of MPI ranks to assign to each logical
+      dimension in the partitioning.
+    */
+    CurvilinearMesh( const std::shared_ptr<Mapping>& mapping,
+                     const int halo_width, MPI_Comm comm,
+                     const std::array<int, num_space_dim>& ranks_per_dim )
+        : _mapping( mapping )
+    {
+        // The logical grid is uniform with unit cell size.
+        std::array<int, num_space_dim> global_num_cell;
+        std::array<bool, num_space_dim> periodic;
+        std::array<double, num_space_dim> global_low_corner;
+        std::array<double, num_space_dim> global_high_corner;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            global_num_cell[d] =
+                CurvilinearMeshMapping<Mapping>::globalNumCell( *_mapping, d );
+            periodic[d] =
+                CurvilinearMeshMapping<Mapping>::periodic( *_mapping, d );
+            global_low_corner[d] = 0.0;
+            global_high_corner[d] = static_cast<double>( global_num_cell[d] );
+        }
+
+        // Create the global mesh.
+        auto global_mesh = Cajita::createUniformGlobalMesh(
+            global_low_corner, global_high_corner, global_num_cell );
+
+        // Build the global grid.
+        auto global_grid = Cajita::createGlobalGrid(
+            comm, global_mesh, periodic,
+            Cajita::ManualBlockPartitioner<num_space_dim>( ranks_per_dim ) );
+
+        // Build the local grid.
+        _local_grid = Cajita::createLocalGrid( global_grid, halo_width );
+    }
+
+    // Get the mesh mapping.
+    const mesh_mapping& mapping() const { return *_mapping; }
+
+    // Get the local grid.
+    std::shared_ptr<local_grid> localGrid() const { return _local_grid; }
+
+  public:
+    std::shared_ptr<mesh_mapping> _mapping;
+    std::shared_ptr<local_grid> _local_grid;
+};
+
+//---------------------------------------------------------------------------//
+// Static type checker.
+template <class>
+struct is_curvilinear_mesh_impl : public std::false_type
+{
+};
+
+template <class Mapping>
+struct is_curvilinear_mesh_impl<CurvilinearMesh<Mapping>>
+    : public std::true_type
+{
+};
+
+template <class T>
+struct is_curvilinear_mesh
+    : public is_curvilinear_mesh_impl<typename std::remove_cv<T>::type>::type
+{
+};
+
+//---------------------------------------------------------------------------//
+// Creation function.
+template <class Mapping>
+auto createCurvilinearMesh(
+    const std::shared_ptr<Mapping>& mapping, const int halo_width,
+    MPI_Comm comm,
+    const std::array<int, Mapping::num_space_dim>& ranks_per_dim )
+{
+    return std::make_shared<CurvilinearMesh<Mapping>>( mapping, halo_width,
+                                                       comm, ranks_per_dim );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Picasso
+
+#endif // end PICASSO_CURVILINEARMESH_HPP

--- a/src/Picasso_FieldManager.hpp
+++ b/src/Picasso_FieldManager.hpp
@@ -70,11 +70,11 @@ class FieldManager
     using mesh_type = Mesh;
 
   public:
-    // Uniform Mesh constructor.
+    // Non-adaptive mesh constructor.
     template <class M = Mesh>
     FieldManager(
         const std::shared_ptr<M>& mesh,
-        typename std::enable_if<is_uniform_mesh<M>::value>::type* = 0 )
+        typename std::enable_if<!is_adaptive_mesh<M>::value>::type* = 0 )
         : _mesh( mesh )
     {
     }
@@ -96,12 +96,13 @@ class FieldManager
         handle->halo =
             Cajita::createHalo<typename Field::PhysicalPosition::value_type,
                                typename Mesh::memory_space>(
-                *( handle->array->layout() ), Cajita::FullHaloPattern() );
+                *( handle->array->layout() ),
+                Cajita::NodeHaloPattern<Mesh::num_space_dim>() );
         _fields.emplace( key, handle );
     }
 
     // Get the mesh.
-    const Mesh& mesh() const { return _mesh; }
+    const Mesh& mesh() const { return *_mesh; }
 
     // Add a field. The field will be allocated and a halo created if it does
     // not already exist.
@@ -166,7 +167,8 @@ class FieldManager
         handle->array = createArray( *_mesh, location, tag );
         handle->halo = Cajita::createHalo<typename FieldTag::value_type,
                                           typename Mesh::memory_space>(
-            *( handle->array->layout() ), Cajita::FullHaloPattern() );
+            *( handle->array->layout() ),
+            Cajita::NodeHaloPattern<Mesh::num_space_dim>() );
         return handle;
     }
 

--- a/src/Picasso_FieldTypes.hpp
+++ b/src/Picasso_FieldTypes.hpp
@@ -16,6 +16,8 @@
 
 #include <Cajita.hpp>
 
+#include <Cabana_Core.hpp>
+
 #include <Kokkos_Core.hpp>
 
 #include <sstream>
@@ -70,7 +72,7 @@ struct FieldLayout
 template <class Views, class... Layouts>
 struct FieldViewTuple
 {
-    static_assert( Cajita::is_parameter_pack<Views>::value,
+    static_assert( Cabana::is_parameter_pack<Views>::value,
                    "Views must be in a Cajita::ParameterPack" );
 
     Views _views;
@@ -78,7 +80,7 @@ struct FieldViewTuple
     template <class Location, class FieldTag>
     KOKKOS_INLINE_FUNCTION const auto& get( Location, FieldTag ) const
     {
-        return Cajita::get<
+        return Cabana::get<
             TypeIndexer<FieldLayout<Location, FieldTag>, Layouts...>::index>(
             _views );
     }
@@ -86,7 +88,7 @@ struct FieldViewTuple
     template <class Location, class FieldTag>
     KOKKOS_INLINE_FUNCTION auto& get( Location, FieldTag )
     {
-        return Cajita::get<
+        return Cabana::get<
             TypeIndexer<FieldLayout<Location, FieldTag>, Layouts...>::index>(
             _views );
     }

--- a/src/Picasso_GridOperator.hpp
+++ b/src/Picasso_GridOperator.hpp
@@ -505,7 +505,7 @@ class GridOperator
         // Create a parameter pack of views. The use of (...) here gets a view
         // of each field in the layout list, wraps it for linear algebra
         // operations, and expands it as a parameter pack.
-        auto views = Cajita::makeParameterPack( Field::createViewWrapper(
+        auto views = Cabana::makeParameterPack( Field::createViewWrapper(
             Layouts(), fm.view( typename Layouts::location(),
                                 typename Layouts::tag() ) )... );
 
@@ -537,7 +537,7 @@ class GridOperator
         // Create a parameter pack of views. The use of (...) here gets a view
         // of each field in the layout list and expands it as a parameter
         // pack.
-        auto scatter_views = Cajita::makeParameterPack(
+        auto scatter_views = Cabana::makeParameterPack(
             Kokkos::Experimental::create_scatter_view( fm.view(
                 typename Layouts::location(), typename Layouts::tag() ) )... );
 
@@ -557,7 +557,7 @@ class GridOperator
         // Create a parameter pack of views. The use of (...) here gets a view
         // of each field in the layout list, wraps it for linear algebra
         // operations, and expands it as a parameter pack.
-        auto views = Cajita::makeParameterPack( Field::createViewWrapper(
+        auto views = Cabana::makeParameterPack( Field::createViewWrapper(
             Layouts(), fm.view( typename Layouts::location(),
                                 typename Layouts::tag() ) )... );
 
@@ -579,7 +579,7 @@ class GridOperator
         // non-const reference to a temporary. Create a parameter pack of
         // views. The use of (...) here gets a view of each field in the
         // layout list and expands it as a parameter pack.
-        auto view_pack = Cajita::makeParameterPack( fm.view(
+        auto view_pack = Cabana::makeParameterPack( fm.view(
             typename Layouts::location(), typename Layouts::tag() )... );
 
         // Assign the parameter pack to the dependency fields.

--- a/src/Picasso_Types.hpp
+++ b/src/Picasso_Types.hpp
@@ -14,11 +14,20 @@
 
 #include <Cajita.hpp>
 
+#include <type_traits>
+
 namespace Picasso
 {
 //---------------------------------------------------------------------------//
 // Logical dimension index.
 using Dim = Cajita::Dim;
+
+//---------------------------------------------------------------------------//
+// Spatial dimension selector.
+template <std::size_t N>
+struct SpaceDim : public std::integral_constant<std::size_t, N>
+{
+};
 
 //---------------------------------------------------------------------------//
 

--- a/src/Picasso_UniformCartesianMeshMapping.hpp
+++ b/src/Picasso_UniformCartesianMeshMapping.hpp
@@ -1,0 +1,183 @@
+/****************************************************************************
+ * Copyright (c) 2021 by the Picasso authors                                *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Picasso library. Picasso is distributed under a *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef PICASSO_UNIFORMCARTESIANMESHMAPPING_HPP
+#define PICASSO_UNIFORMCARTESIANMESHMAPPING_HPP
+
+#include <Picasso_BatchedLinearAlgebra.hpp>
+#include <Picasso_CurvilinearMesh.hpp>
+#include <Picasso_FieldManager.hpp>
+#include <Picasso_Types.hpp>
+
+#include <Cajita.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <mpi.h>
+
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+namespace Picasso
+{
+//---------------------------------------------------------------------------//
+/*!
+  \class UniformCartesianMeshMapping
+  \brief Uniform Cartesian mesh mapping function.
+ */
+template <class MemorySpace, std::size_t NumSpaceDim>
+struct UniformCartesianMeshMapping
+{
+    using memory_space = MemorySpace;
+    static constexpr std::size_t num_space_dim = NumSpaceDim;
+
+    double _cell_size;
+    double _inv_cell_size;
+    double _cell_measure;
+    double _inv_cell_measure;
+    Kokkos::Array<int, NumSpaceDim> _global_num_cell;
+    Kokkos::Array<bool, NumSpaceDim> _periodic;
+    Kokkos::Array<double, 2 * NumSpaceDim> _global_bounding_box;
+};
+
+//---------------------------------------------------------------------------//
+// Template interface implementation.
+template <class MemorySpace, std::size_t NumSpaceDim>
+class CurvilinearMeshMapping<
+    UniformCartesianMeshMapping<MemorySpace, NumSpaceDim>>
+{
+  public:
+    using memory_space = MemorySpace;
+    static constexpr std::size_t num_space_dim = NumSpaceDim;
+    using mesh_mapping = UniformCartesianMeshMapping<MemorySpace, NumSpaceDim>;
+
+    // Get the global number of cells in given logical dimension that construct
+    // the mapping.
+    static int globalNumCell( const mesh_mapping& mapping, const int dim )
+    {
+        return mapping._global_num_cell[dim];
+    }
+
+    // Get the periodicity of a given logical dimension of the mapping.
+    static bool periodic( const mesh_mapping& mapping, const int dim )
+    {
+        return mapping._periodic[dim];
+    }
+
+    // Forward mapping. Given coordinates in the reference frame
+    // compute the coordinates in the physical frame.
+    template <class ReferenceCoords, class PhysicalCoords>
+    static KOKKOS_INLINE_FUNCTION void
+    mapToPhysicalFrame( const mesh_mapping& mapping,
+                        const ReferenceCoords& reference_coords,
+                        PhysicalCoords& physical_coords )
+    {
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            physical_coords( d ) = mapping._global_bounding_box[d] +
+                                   reference_coords( d ) * mapping._cell_size;
+    }
+
+    // Given coordinates in the reference frame compute the grid
+    // transformation metrics. This is the jacobian of the forward mapping,
+    // its determinant, and inverse.
+    template <class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION void transformationMetrics(
+        const mesh_mapping& mapping, const ReferenceCoords&,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type, NumSpaceDim,
+                              NumSpaceDim>& jacobian,
+        typename ReferenceCoords::value_type& jacobian_det,
+        LinearAlgebra::Matrix<typename ReferenceCoords::value_type, NumSpaceDim,
+                              NumSpaceDim>& jacobian_inv )
+    {
+        for ( std::size_t i = 0; i < num_space_dim; ++i )
+            for ( std::size_t j = 0; j < num_space_dim; ++j )
+                jacobian( i, j ) = ( i == j ) ? mapping._cell_size : 0.0;
+
+        jacobian_det = mapping._inv_cell_measure;
+
+        for ( std::size_t i = 0; i < num_space_dim; ++i )
+            for ( std::size_t j = 0; j < num_space_dim; ++j )
+                jacobian_inv( i, j ) =
+                    ( i == j ) ? mapping._inv_cell_size : 0.0;
+    }
+
+    // Reverse mapping. Given coordinates in the physical frame compute the
+    // coordinates in the reference frame. Return whether or not the
+    // mapping succeeded.
+    template <class PhysicalCoords, class ReferenceCoords>
+    static KOKKOS_INLINE_FUNCTION bool
+    mapToReferenceFrame( const mesh_mapping& mapping,
+                         const PhysicalCoords& physical_coords,
+                         ReferenceCoords& reference_coords )
+    {
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            reference_coords( d ) =
+                ( physical_coords( d ) - mapping._global_bounding_box[d] ) *
+                mapping._inv_cell_size;
+        return true;
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Create a uniform mesh. Creates a mapping, a mesh, a field manager, a
+// coordinate array in the field manager, and assigns the global mesh bounds to
+// the mapping. A field manager containing the mesh is returned.
+template <class MemorySpace, std::size_t NumSpaceDim>
+auto createUniformCartesianMesh(
+    MemorySpace, const double cell_size,
+    const Kokkos::Array<double, 2 * NumSpaceDim>& global_bounding_box,
+    const Kokkos::Array<bool, NumSpaceDim>& periodic, const int halo_width,
+    MPI_Comm comm, const std::array<int, NumSpaceDim>& ranks_per_dim )
+{
+    // Create the mapping.
+    auto mapping = std::make_shared<
+        UniformCartesianMeshMapping<MemorySpace, NumSpaceDim>>();
+    mapping->_cell_size = cell_size;
+    mapping->_inv_cell_size = 1.0 / cell_size;
+    mapping->_cell_measure = pow( cell_size, NumSpaceDim );
+    mapping->_inv_cell_measure = 1.0 / mapping->_cell_measure;
+    mapping->_periodic = periodic;
+    mapping->_global_bounding_box = global_bounding_box;
+    for ( std::size_t d = 0; d < NumSpaceDim; ++d )
+    {
+        mapping->_global_num_cell[d] = std::rint(
+            ( global_bounding_box[NumSpaceDim + d] - global_bounding_box[d] ) /
+            cell_size );
+    }
+
+    // Because the mesh is uniform check that the domain is evenly
+    // divisible by the cell size in each dimension within round-off
+    // error. This will let us do cheaper math for particle location.
+    for ( std::size_t d = 0; d < NumSpaceDim; ++d )
+    {
+        double extent = mapping->_global_num_cell[d] * cell_size;
+        if ( std::abs( extent - ( global_bounding_box[NumSpaceDim + d] -
+                                  global_bounding_box[d] ) ) >
+             std::numeric_limits<float>::epsilon() )
+            throw std::logic_error(
+                "Extent not evenly divisible by uniform cell size" );
+    }
+
+    // Create mesh.
+    auto mesh =
+        createCurvilinearMesh( mapping, halo_width, comm, ranks_per_dim );
+
+    // Create field manager.
+    auto manager = createFieldManager( mesh );
+    return manager;
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Picasso
+
+#endif // end PICASSO_UNIFORMCARTESIANMESHMAPPING_HPP

--- a/src/Picasso_UniformMesh.hpp
+++ b/src/Picasso_UniformMesh.hpp
@@ -40,6 +40,8 @@ class UniformMesh
 
     using local_grid = Cajita::LocalGrid<cajita_mesh>;
 
+    static constexpr std::size_t num_space_dim = 3;
+
     // Construct a mesh manager from the problem bounding box and a property
     // tree.
     UniformMesh( const boost::property_tree::ptree& ptree,

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -57,6 +57,10 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/polypic_test.json
   COPYONLY)
 configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/inputs/field_manager_test.json
+  ${CMAKE_CURRENT_BINARY_DIR}/field_manager_test.json
+  COPYONLY)
+configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/inputs/facet_init_example.json
   ${CMAKE_CURRENT_BINARY_DIR}/facet_init_example.json
   COPYONLY)
@@ -160,6 +164,8 @@ Picasso_add_tests(MPI NAMES
   ParticleList
   ParticleInit
   ParticleCommunication
+  UniformCartesianMeshMapping
+  BilinearMeshMapping
   UniformMesh
   AdaptiveMesh
   FieldManager

--- a/unit_test/inputs/field_manager_test.json
+++ b/unit_test/inputs/field_manager_test.json
@@ -1,0 +1,10 @@
+{
+    "mesh": {
+        "global_num_cell": [40, 40, 40],
+        "periodic": [true, true, true],
+        "partitioner": {
+            "type": "uniform_dim"
+        },
+        "halo_cell_width": 2
+    }
+}

--- a/unit_test/tstAPIC.hpp
+++ b/unit_test/tstAPIC.hpp
@@ -566,9 +566,9 @@ void collocatedTest()
     double pz = -3.34;
 
     // Particle cell location.
-    int cx = 118;
-    int cy = 83;
-    int cz = 93;
+    int cx = 120;
+    int cy = 85;
+    int cz = 95;
 
     // Particle velocity.
     Kokkos::View<double[3], TEST_MEMSPACE> pu( "pu" );
@@ -583,10 +583,13 @@ void collocatedTest()
         "fill_grid_vector", TEST_EXECSPACE(),
         grid_vector->layout()->indexSpace( Cajita::Own(), Cajita::Local() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k, const int d ) {
-            gv_view( i, j, k, d ) = 0.0000000001 * ( d + 1 ) * pow( i, 5 ) -
-                                    0.0000000012 * pow( ( d + 1 ) + j * i, 3 ) +
-                                    0.0000000001 * pow( i * j * k, 2 ) +
-                                    pow( ( d + 1 ), 2 );
+            int ic = i - 2;
+            int jc = j - 2;
+            int kc = k - 2;
+            gv_view( i, j, k, d ) =
+                0.0000000001 * ( d + 1 ) * pow( ic, 5 ) -
+                0.0000000012 * pow( ( d + 1 ) + jc * ic, 3 ) +
+                0.0000000001 * pow( ic * jc * kc, 2 ) + pow( ( d + 1 ), 2 );
         } );
 
     // Check the grid velocity. Computed in Mathematica.
@@ -740,9 +743,9 @@ void staggeredTest()
     double pz = -3.34;
 
     // Particle cell location.
-    int cx = 118;
-    int cy = 83;
-    int cz = 93;
+    int cx = 120;
+    int cy = 85;
+    int cz = 95;
 
     // Particle velocity.
     Kokkos::View<double[3], TEST_MEMSPACE> pu( "pu" );
@@ -757,10 +760,13 @@ void staggeredTest()
         "fill_grid_scalar", TEST_EXECSPACE(),
         grid_scalar->layout()->indexSpace( Cajita::Own(), Cajita::Local() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k, const int ) {
+            int ic = i - 2;
+            int jc = j - 2;
+            int kc = k - 2;
             gs_view( i, j, k, 0 ) =
-                0.0000000001 * ( Dim + 1 ) * pow( i, 5 ) -
-                0.0000000012 * pow( ( Dim + 1 ) + j * i, 3 ) +
-                0.0000000001 * pow( i * j * k, 2 ) + pow( ( Dim + 1 ), 2 );
+                0.0000000001 * ( Dim + 1 ) * pow( ic, 5 ) -
+                0.0000000012 * pow( ( Dim + 1 ) + jc * ic, 3 ) +
+                0.0000000001 * pow( ic * jc * kc, 2 ) + pow( ( Dim + 1 ), 2 );
         } );
 
     // Check the grid velocity. Computed in Mathematica.

--- a/unit_test/tstBilinearMeshMapping.hpp
+++ b/unit_test/tstBilinearMeshMapping.hpp
@@ -1,0 +1,360 @@
+/****************************************************************************
+ * Copyright (c) 2021 by the Picasso authors                                *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Picasso library. Picasso is distributed under a *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Picasso_BatchedLinearAlgebra.hpp>
+#include <Picasso_BilinearMeshMapping.hpp>
+#include <Picasso_CurvilinearMesh.hpp>
+#include <Picasso_Types.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+using namespace Picasso;
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+void mappingTest3d()
+{
+    // Global parameters.
+    Kokkos::Array<double, 6> global_box = { -10.0, -10.0, -10.0,
+                                            10.0,  10.0,  10.0 };
+    double cell_size = 0.5;
+    int num_cell = 20.0 / cell_size;
+    int halo_width = 1;
+    Kokkos::Array<bool, 3> periodic = { true, false, true };
+
+    // Partition only in the x direction.
+    std::array<int, 3> ranks_per_dim = { 1, 1, 1 };
+    MPI_Comm_size( MPI_COMM_WORLD, &ranks_per_dim[0] );
+
+    // Uniform bilinear mesh generator.
+    UniformBilinearMeshGenerator<3> generator = { cell_size, global_box,
+                                                  periodic };
+
+    // Create the mesh and field manager.
+    auto manager = createBilinearMesh( TEST_MEMSPACE{}, generator, halo_width,
+                                       MPI_COMM_WORLD, ranks_per_dim );
+
+    // Check the mapping.
+    auto mapping = manager->mesh().mapping();
+    using mapping_type = decltype( mapping );
+    for ( int d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( num_cell, mapping._global_num_cell[d] );
+        EXPECT_EQ( periodic[d], mapping._periodic[d] );
+    }
+
+    // Check grid.
+    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_mesh = global_grid.globalMesh();
+
+    EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
+    EXPECT_EQ( global_mesh.lowCorner( 1 ), 0.0 );
+    EXPECT_EQ( global_mesh.lowCorner( 2 ), 0.0 );
+
+    EXPECT_EQ( global_mesh.highCorner( 0 ), num_cell );
+    EXPECT_EQ( global_mesh.highCorner( 1 ), num_cell );
+    EXPECT_EQ( global_mesh.highCorner( 2 ), num_cell );
+
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 0 ), num_cell );
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 1 ), num_cell );
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 2 ), num_cell );
+
+    EXPECT_TRUE( global_grid.isPeriodic( 0 ) );
+    EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
+    EXPECT_TRUE( global_grid.isPeriodic( 2 ) );
+
+    auto local_grid = manager->mesh().localGrid();
+    EXPECT_EQ( local_grid->haloCellWidth(), 1 );
+
+    // Give a bad guess that is still in the local domain to test the ability
+    // to search.
+    auto global_cells = local_grid->indexSpace( Cajita::Own(), Cajita::Cell(),
+                                                Cajita::Global() );
+    Kokkos::Array<double, 3> guess = {
+        static_cast<double>( global_cells.min( Dim::I ) ),
+        static_cast<double>( global_cells.min( Dim::J ) ),
+        static_cast<double>( global_cells.min( Dim::K ) ) };
+
+    // Check mapping.
+    auto ghosted_cells = local_grid->indexSpace(
+        Cajita::Ghost(), Cajita::Cell(), Cajita::Local() );
+    auto local_mesh = Cajita::createLocalMesh<TEST_MEMSPACE>( *local_grid );
+    Kokkos::View<double*** [3], TEST_MEMSPACE> cell_forward_map(
+        "cell_forward_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<double*** [3], TEST_MEMSPACE> cell_reverse_map(
+        "cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<bool***, TEST_MEMSPACE> cell_map_success(
+        "cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<double*** [3], TEST_MEMSPACE> default_cell_reverse_map(
+        "default_cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<bool***, TEST_MEMSPACE> default_cell_map_success(
+        "default_cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Cajita::grid_parallel_for(
+        "check_mapping", TEST_EXECSPACE{}, ghosted_cells,
+        KOKKOS_LAMBDA( const int i, const int j, const int k ) {
+            // Map to physical frame.
+            LinearAlgebra::Vector<double, 3> cell_coords;
+            int ijk[3] = { i, j, k };
+            local_mesh.coordinates( Cajita::Cell{}, ijk, cell_coords.data() );
+
+            LinearAlgebra::VectorView<double, 3> phys_coords(
+                &cell_forward_map( i, j, k, 0 ), cell_forward_map.stride( 3 ) );
+            CurvilinearMeshMapping<mapping_type>::mapToPhysicalFrame(
+                mapping, cell_coords, phys_coords );
+
+            // Map to reference frame. Use the bad guess to test search.
+            LinearAlgebra::VectorView<double, 3> ref_coords(
+                &cell_reverse_map( i, j, k, 0 ), cell_reverse_map.stride( 3 ) );
+            ref_coords = { guess[Dim::I], guess[Dim::J], guess[Dim::K] };
+            cell_map_success( i, j, k ) =
+                CurvilinearMeshMapping<mapping_type>::mapToReferenceFrame(
+                    mapping, phys_coords, ref_coords );
+
+            // Default map to reference frame. Use a good guess in the cell.
+            LinearAlgebra::VectorView<double, 3> default_ref_coords(
+                &default_cell_reverse_map( i, j, k, 0 ),
+                default_cell_reverse_map.stride( 3 ) );
+            default_ref_coords = { cell_coords( Dim::I ) - 0.1,
+                                   cell_coords( Dim::J ) - 0.1,
+                                   cell_coords( Dim::K ) - 0.1 };
+            default_cell_map_success( i, j, k ) = DefaultCurvilinearMeshMapping<
+                mapping_type>::mapToReferenceFrame( mapping, phys_coords,
+                                                    default_ref_coords );
+        } );
+
+    auto forward_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_forward_map );
+    auto reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_reverse_map );
+    auto map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_map_success );
+    auto default_reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_reverse_map );
+    auto default_map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_map_success );
+
+    auto global_offset_i =
+        local_grid->globalGrid().globalOffset( Dim::I ) - halo_width;
+    auto global_offset_j =
+        local_grid->globalGrid().globalOffset( Dim::J ) - halo_width;
+    auto global_offset_k =
+        local_grid->globalGrid().globalOffset( Dim::K ) - halo_width;
+
+    for ( int i = ghosted_cells.min( Dim::I ); i < ghosted_cells.max( Dim::I );
+          ++i )
+        for ( int j = ghosted_cells.min( Dim::J );
+              j < ghosted_cells.max( Dim::J ); ++j )
+            for ( int k = ghosted_cells.min( Dim::K );
+                  k < ghosted_cells.max( Dim::K ); ++k )
+            {
+                EXPECT_FLOAT_EQ( cell_size * ( global_offset_i + i + 0.5 ) +
+                                     global_box[0],
+                                 forward_map_h( i, j, k, Dim::I ) );
+                EXPECT_FLOAT_EQ( cell_size * ( global_offset_j + j + 0.5 ) +
+                                     global_box[1],
+                                 forward_map_h( i, j, k, Dim::J ) );
+                EXPECT_FLOAT_EQ( cell_size * ( global_offset_k + k + 0.5 ) +
+                                     global_box[2],
+                                 forward_map_h( i, j, k, Dim::K ) );
+
+                EXPECT_TRUE( map_success_h( i, j, k ) );
+
+                EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                                 reverse_map_h( i, j, k, Dim::I ) );
+                EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                                 reverse_map_h( i, j, k, Dim::J ) );
+                EXPECT_FLOAT_EQ( global_offset_k + k + 0.5,
+                                 reverse_map_h( i, j, k, Dim::K ) );
+
+                EXPECT_TRUE( default_map_success_h( i, j, k ) );
+
+                EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                                 default_reverse_map_h( i, j, k, Dim::I ) );
+                EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                                 default_reverse_map_h( i, j, k, Dim::J ) );
+                EXPECT_FLOAT_EQ( global_offset_k + k + 0.5,
+                                 default_reverse_map_h( i, j, k, Dim::K ) );
+            }
+}
+
+//---------------------------------------------------------------------------//
+void mappingTest2d()
+{
+    // Global parameters.
+    Kokkos::Array<double, 4> global_box = { -10.0, -10.0, 10.0, 10.0 };
+    double cell_size = 0.5;
+    int num_cell = 20.0 / cell_size;
+    int halo_width = 1;
+    Kokkos::Array<bool, 2> periodic = { true, false };
+
+    // Partition only in the x direction.
+    std::array<int, 2> ranks_per_dim = { 1, 1 };
+    MPI_Comm_size( MPI_COMM_WORLD, &ranks_per_dim[0] );
+
+    // Uniform bilinear mesh generator.
+    UniformBilinearMeshGenerator<2> generator = { cell_size, global_box,
+                                                  periodic };
+
+    // Create the mesh and field manager.
+    auto manager = createBilinearMesh( TEST_MEMSPACE{}, generator, halo_width,
+                                       MPI_COMM_WORLD, ranks_per_dim );
+
+    // Check the mapping.
+    auto mapping = manager->mesh().mapping();
+    using mapping_type = decltype( mapping );
+    for ( int d = 0; d < 2; ++d )
+    {
+        EXPECT_EQ( num_cell, mapping._global_num_cell[d] );
+        EXPECT_EQ( periodic[d], mapping._periodic[d] );
+    }
+
+    // Check grid.
+    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_mesh = global_grid.globalMesh();
+
+    EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
+    EXPECT_EQ( global_mesh.lowCorner( 1 ), 0.0 );
+
+    EXPECT_EQ( global_mesh.highCorner( 0 ), num_cell );
+    EXPECT_EQ( global_mesh.highCorner( 1 ), num_cell );
+
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 0 ), num_cell );
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 1 ), num_cell );
+
+    EXPECT_TRUE( global_grid.isPeriodic( 0 ) );
+    EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
+
+    auto local_grid = manager->mesh().localGrid();
+    EXPECT_EQ( local_grid->haloCellWidth(), 1 );
+
+    // Give a bad guess that is still in the local domain to test the ability
+    // to search.
+    auto global_cells = local_grid->indexSpace( Cajita::Own(), Cajita::Cell(),
+                                                Cajita::Global() );
+    Kokkos::Array<double, 2> guess = {
+        static_cast<double>( global_cells.min( Dim::I ) ),
+        static_cast<double>( global_cells.min( Dim::J ) ) };
+
+    // Check mapping.
+    auto ghosted_cells = local_grid->indexSpace(
+        Cajita::Ghost(), Cajita::Cell(), Cajita::Local() );
+    auto local_mesh = Cajita::createLocalMesh<TEST_MEMSPACE>( *local_grid );
+    Kokkos::View<double** [2], TEST_MEMSPACE> cell_forward_map(
+        "cell_forward_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<double** [2], TEST_MEMSPACE> cell_reverse_map(
+        "cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<bool**, TEST_MEMSPACE> cell_map_success(
+        "cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<double** [2], TEST_MEMSPACE> default_cell_reverse_map(
+        "default_cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<bool**, TEST_MEMSPACE> default_cell_map_success(
+        "default_cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Cajita::grid_parallel_for(
+        "check_mapping", TEST_EXECSPACE{}, ghosted_cells,
+        KOKKOS_LAMBDA( const int i, const int j ) {
+            // Map to physical frame.
+            LinearAlgebra::Vector<double, 2> cell_coords;
+            int ijk[2] = { i, j };
+            local_mesh.coordinates( Cajita::Cell{}, ijk, cell_coords.data() );
+            LinearAlgebra::VectorView<double, 2> phys_coords(
+                &cell_forward_map( i, j, 0 ), cell_forward_map.stride( 2 ) );
+            CurvilinearMeshMapping<mapping_type>::mapToPhysicalFrame(
+                mapping, cell_coords, phys_coords );
+
+            // Map to reference frame. Use a bad guess to test the search.
+            LinearAlgebra::VectorView<double, 2> ref_coords(
+                &cell_reverse_map( i, j, 0 ), cell_reverse_map.stride( 2 ) );
+            ref_coords = { guess[Dim::I], guess[Dim::J] };
+            cell_map_success( i, j ) =
+                CurvilinearMeshMapping<mapping_type>::mapToReferenceFrame(
+                    mapping, phys_coords, ref_coords );
+
+            // Default map to reference frame. Use a good guess that is in the
+            // cell.
+            LinearAlgebra::VectorView<double, 2> default_ref_coords(
+                &default_cell_reverse_map( i, j, 0 ),
+                default_cell_reverse_map.stride( 2 ) );
+            default_ref_coords = { cell_coords( Dim::I ) - 0.1,
+                                   cell_coords( Dim::J ) - 0.1 };
+            default_cell_map_success( i, j ) = DefaultCurvilinearMeshMapping<
+                mapping_type>::mapToReferenceFrame( mapping, phys_coords,
+                                                    default_ref_coords );
+        } );
+
+    auto forward_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_forward_map );
+    auto reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_reverse_map );
+    auto map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_map_success );
+    auto default_reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_reverse_map );
+    auto default_map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_map_success );
+
+    auto global_offset_i =
+        local_grid->globalGrid().globalOffset( Dim::I ) - halo_width;
+    auto global_offset_j =
+        local_grid->globalGrid().globalOffset( Dim::J ) - halo_width;
+
+    for ( int i = ghosted_cells.min( Dim::I ); i < ghosted_cells.max( Dim::I );
+          ++i )
+        for ( int j = ghosted_cells.min( Dim::J );
+              j < ghosted_cells.max( Dim::J ); ++j )
+        {
+            EXPECT_FLOAT_EQ( cell_size * ( global_offset_i + i + 0.5 ) +
+                                 global_box[0],
+                             forward_map_h( i, j, Dim::I ) );
+            EXPECT_FLOAT_EQ( cell_size * ( global_offset_j + j + 0.5 ) +
+                                 global_box[1],
+                             forward_map_h( i, j, Dim::J ) );
+
+            EXPECT_TRUE( map_success_h( i, j ) );
+
+            EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                             reverse_map_h( i, j, Dim::I ) );
+            EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                             reverse_map_h( i, j, Dim::J ) );
+
+            EXPECT_TRUE( default_map_success_h( i, j ) );
+
+            EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                             default_reverse_map_h( i, j, Dim::I ) );
+            EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                             default_reverse_map_h( i, j, Dim::J ) );
+        }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, mapping_test_3d ) { mappingTest3d(); }
+
+TEST( TEST_CATEGORY, mapping_test_2d ) { mappingTest2d(); }
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/unit_test/tstFieldManager.hpp
+++ b/unit_test/tstFieldManager.hpp
@@ -41,7 +41,7 @@ void checkGather( const View& view, const IndexSpace& index_space,
 void uniformTest()
 {
     // Get inputs for mesh.
-    InputParser parser( "uniform_mesh_test_1.json", "json" );
+    InputParser parser( "field_manager_test.json", "json" );
     Kokkos::Array<double, 6> global_box = { -10.0, -10.0, -10.0,
                                             10.0,  10.0,  10.0 };
     int minimum_halo_size = 0;
@@ -147,7 +147,7 @@ void uniformTest()
 void adaptiveTest()
 {
     // Get inputs for mesh.
-    InputParser parser( "adaptive_mesh_test_1.json", "json" );
+    InputParser parser( "field_manager_test.json", "json" );
     Kokkos::Array<double, 6> global_box = { -10.0, -10.0, -10.0,
                                             10.0,  10.0,  10.0 };
     int minimum_halo_size = 1;

--- a/unit_test/tstPolyPIC.hpp
+++ b/unit_test/tstPolyPIC.hpp
@@ -222,9 +222,9 @@ void collocatedTest()
     double pz = -3.34;
 
     // Particle cell location.
-    int cx = 118;
-    int cy = 83;
-    int cz = 93;
+    int cx = 120;
+    int cy = 85;
+    int cz = 95;
 
     // Number of velocity modes.
     const int num_mode = OrderTraits<Order>::num_mode;
@@ -241,10 +241,13 @@ void collocatedTest()
         "fill_grid_vector", TEST_EXECSPACE(),
         grid_vector->layout()->indexSpace( Cajita::Own(), Cajita::Local() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k, const int d ) {
-            gv_view( i, j, k, d ) = 0.0000000001 * ( d + 1 ) * pow( i, 5 ) -
-                                    0.0000000012 * pow( ( d + 1 ) + j * i, 3 ) +
-                                    0.0000000001 * pow( i * j * k, 2 ) +
-                                    pow( ( d + 1 ), 2 );
+            int ic = i - 2;
+            int jc = j - 2;
+            int kc = k - 2;
+            gv_view( i, j, k, d ) =
+                0.0000000001 * ( d + 1 ) * pow( ic, 5 ) -
+                0.0000000012 * pow( ( d + 1 ) + jc * ic, 3 ) +
+                0.0000000001 * pow( ic * jc * kc, 2 ) + pow( ( d + 1 ), 2 );
         } );
 
     // Check the grid velocity. Computed in Mathematica.
@@ -388,9 +391,9 @@ void staggeredTest()
     double pz = -3.34;
 
     // Particle cell location.
-    int cx = 118;
-    int cy = 83;
-    int cz = 93;
+    int cx = 120;
+    int cy = 85;
+    int cz = 95;
 
     // Number of velocity modes.
     const int num_mode = OrderTraits<Order>::num_mode;
@@ -407,10 +410,13 @@ void staggeredTest()
         "fill_grid_scalar", TEST_EXECSPACE(),
         grid_scalar->layout()->indexSpace( Cajita::Own(), Cajita::Local() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k, const int ) {
+            int ic = i - 2;
+            int jc = j - 2;
+            int kc = k - 2;
             gs_view( i, j, k, 0 ) =
-                0.0000000001 * ( Dim + 1 ) * pow( i, 5 ) -
-                0.0000000012 * pow( ( Dim + 1 ) + j * i, 3 ) +
-                0.0000000001 * pow( i * j * k, 2 ) + pow( ( Dim + 1 ), 2 );
+                0.0000000001 * ( Dim + 1 ) * pow( ic, 5 ) -
+                0.0000000012 * pow( ( Dim + 1 ) + jc * ic, 3 ) +
+                0.0000000001 * pow( ic * jc * kc, 2 ) + pow( ( Dim + 1 ), 2 );
         } );
 
     // Check the grid velocity. Computed in Mathematica.

--- a/unit_test/tstUniformCartesianMeshMapping.hpp
+++ b/unit_test/tstUniformCartesianMeshMapping.hpp
@@ -1,0 +1,347 @@
+/****************************************************************************
+ * Copyright (c) 2021 by the Picasso authors                                *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Picasso library. Picasso is distributed under a *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Picasso_BatchedLinearAlgebra.hpp>
+#include <Picasso_CurvilinearMesh.hpp>
+#include <Picasso_Types.hpp>
+#include <Picasso_UniformCartesianMeshMapping.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+using namespace Picasso;
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+void mappingTest3d()
+{
+    // Global parameters.
+    Kokkos::Array<double, 6> global_box = { -10.0, -10.0, -10.0,
+                                            10.0,  10.0,  10.0 };
+    double cell_size = 0.5;
+    int num_cell = 20.0 / cell_size;
+    int halo_width = 1;
+    Kokkos::Array<bool, 3> periodic = { true, false, true };
+
+    // Partition only in the x direction.
+    std::array<int, 3> ranks_per_dim = { 1, 1, 1 };
+    MPI_Comm_size( MPI_COMM_WORLD, &ranks_per_dim[0] );
+
+    // Create the mesh and field manager.
+    auto manager = createUniformCartesianMesh( TEST_MEMSPACE{}, cell_size,
+                                               global_box, periodic, halo_width,
+                                               MPI_COMM_WORLD, ranks_per_dim );
+
+    // Check the mapping data.
+    auto mapping = manager->mesh().mapping();
+    using mapping_type = decltype( mapping );
+    EXPECT_EQ( cell_size, mapping._cell_size );
+    EXPECT_EQ( 1.0 / cell_size, mapping._inv_cell_size );
+    EXPECT_EQ( cell_size * cell_size * cell_size, mapping._cell_measure );
+    EXPECT_EQ( 1.0 / ( cell_size * cell_size * cell_size ),
+               mapping._inv_cell_measure );
+    for ( int d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( num_cell, mapping._global_num_cell[d] );
+        EXPECT_EQ( periodic[d], mapping._periodic[d] );
+    }
+
+    // Check grid.
+    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_mesh = global_grid.globalMesh();
+
+    EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
+    EXPECT_EQ( global_mesh.lowCorner( 1 ), 0.0 );
+    EXPECT_EQ( global_mesh.lowCorner( 2 ), 0.0 );
+
+    EXPECT_EQ( global_mesh.highCorner( 0 ), num_cell );
+    EXPECT_EQ( global_mesh.highCorner( 1 ), num_cell );
+    EXPECT_EQ( global_mesh.highCorner( 2 ), num_cell );
+
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 0 ), num_cell );
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 1 ), num_cell );
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 2 ), num_cell );
+
+    EXPECT_TRUE( global_grid.isPeriodic( 0 ) );
+    EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
+    EXPECT_TRUE( global_grid.isPeriodic( 2 ) );
+
+    auto local_grid = manager->mesh().localGrid();
+    EXPECT_EQ( local_grid->haloCellWidth(), 1 );
+
+    // Check mapping.
+    auto ghosted_cells = local_grid->indexSpace(
+        Cajita::Ghost(), Cajita::Cell(), Cajita::Local() );
+    auto local_mesh = Cajita::createLocalMesh<TEST_MEMSPACE>( *local_grid );
+    Kokkos::View<double*** [3], TEST_MEMSPACE> cell_forward_map(
+        "cell_forward_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<double*** [3], TEST_MEMSPACE> cell_reverse_map(
+        "cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<bool***, TEST_MEMSPACE> cell_map_success(
+        "cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<double*** [3], TEST_MEMSPACE> default_cell_reverse_map(
+        "default_cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Kokkos::View<bool***, TEST_MEMSPACE> default_cell_map_success(
+        "default_cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ), ghosted_cells.extent( Dim::K ) );
+    Cajita::grid_parallel_for(
+        "check_mapping", TEST_EXECSPACE{}, ghosted_cells,
+        KOKKOS_LAMBDA( const int i, const int j, const int k ) {
+            // Map to physical frame.
+            LinearAlgebra::Vector<double, 3> cell_coords;
+            int ijk[3] = { i, j, k };
+            local_mesh.coordinates( Cajita::Cell{}, ijk, cell_coords.data() );
+            LinearAlgebra::VectorView<double, 3> phys_coords(
+                &cell_forward_map( i, j, k, 0 ), cell_forward_map.stride( 3 ) );
+            CurvilinearMeshMapping<mapping_type>::mapToPhysicalFrame(
+                mapping, cell_coords, phys_coords );
+
+            // Map to reference frame.
+            LinearAlgebra::VectorView<double, 3> ref_coords(
+                &cell_reverse_map( i, j, k, 0 ), cell_reverse_map.stride( 3 ) );
+            ref_coords = { cell_coords( Dim::I ) - 0.1,
+                           cell_coords( Dim::J ) - 0.1,
+                           cell_coords( Dim::K ) - 0.1 };
+            cell_map_success( i, j, k ) =
+                CurvilinearMeshMapping<mapping_type>::mapToReferenceFrame(
+                    mapping, phys_coords, ref_coords );
+
+            // Default map to reference frame.
+            LinearAlgebra::VectorView<double, 3> default_ref_coords(
+                &default_cell_reverse_map( i, j, k, 0 ),
+                default_cell_reverse_map.stride( 3 ) );
+            default_ref_coords = { cell_coords( Dim::I ) - 0.1,
+                                   cell_coords( Dim::J ) - 0.1,
+                                   cell_coords( Dim::K ) - 0.1 };
+            default_cell_map_success( i, j, k ) = DefaultCurvilinearMeshMapping<
+                mapping_type>::mapToReferenceFrame( mapping, phys_coords,
+                                                    default_ref_coords );
+        } );
+
+    auto forward_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_forward_map );
+    auto reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_reverse_map );
+    auto map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_map_success );
+    auto default_reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_reverse_map );
+    auto default_map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_map_success );
+
+    auto global_offset_i =
+        local_grid->globalGrid().globalOffset( Dim::I ) - halo_width;
+    auto global_offset_j =
+        local_grid->globalGrid().globalOffset( Dim::J ) - halo_width;
+    auto global_offset_k =
+        local_grid->globalGrid().globalOffset( Dim::K ) - halo_width;
+
+    for ( int i = ghosted_cells.min( Dim::I ); i < ghosted_cells.max( Dim::I );
+          ++i )
+        for ( int j = ghosted_cells.min( Dim::J );
+              j < ghosted_cells.max( Dim::J ); ++j )
+            for ( int k = ghosted_cells.min( Dim::K );
+                  k < ghosted_cells.max( Dim::K ); ++k )
+            {
+                EXPECT_FLOAT_EQ( cell_size * ( global_offset_i + i + 0.5 ) +
+                                     global_box[0],
+                                 forward_map_h( i, j, k, Dim::I ) );
+                EXPECT_FLOAT_EQ( cell_size * ( global_offset_j + j + 0.5 ) +
+                                     global_box[1],
+                                 forward_map_h( i, j, k, Dim::J ) );
+                EXPECT_FLOAT_EQ( cell_size * ( global_offset_k + k + 0.5 ) +
+                                     global_box[2],
+                                 forward_map_h( i, j, k, Dim::K ) );
+
+                EXPECT_TRUE( map_success_h( i, j, k ) );
+
+                EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                                 reverse_map_h( i, j, k, Dim::I ) );
+                EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                                 reverse_map_h( i, j, k, Dim::J ) );
+                EXPECT_FLOAT_EQ( global_offset_k + k + 0.5,
+                                 reverse_map_h( i, j, k, Dim::K ) );
+
+                EXPECT_TRUE( default_map_success_h( i, j, k ) );
+
+                EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                                 default_reverse_map_h( i, j, k, Dim::I ) );
+                EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                                 default_reverse_map_h( i, j, k, Dim::J ) );
+                EXPECT_FLOAT_EQ( global_offset_k + k + 0.5,
+                                 default_reverse_map_h( i, j, k, Dim::K ) );
+            }
+}
+
+//---------------------------------------------------------------------------//
+void mappingTest2d()
+{
+    // Global parameters.
+    Kokkos::Array<double, 4> global_box = { -10.0, -10.0, 10.0, 10.0 };
+    double cell_size = 0.5;
+    int num_cell = 20.0 / cell_size;
+    int halo_width = 1;
+    Kokkos::Array<bool, 2> periodic = { true, false };
+
+    // Partition only in the x direction.
+    std::array<int, 2> ranks_per_dim = { 1, 1 };
+    MPI_Comm_size( MPI_COMM_WORLD, &ranks_per_dim[0] );
+
+    // Create the mesh and field manager.
+    auto manager = createUniformCartesianMesh( TEST_MEMSPACE{}, cell_size,
+                                               global_box, periodic, halo_width,
+                                               MPI_COMM_WORLD, ranks_per_dim );
+
+    // Check the mapping data.
+    auto mapping = manager->mesh().mapping();
+    using mapping_type = decltype( mapping );
+    EXPECT_EQ( cell_size, mapping._cell_size );
+    EXPECT_EQ( 1.0 / cell_size, mapping._inv_cell_size );
+    EXPECT_EQ( cell_size * cell_size, mapping._cell_measure );
+    EXPECT_EQ( 1.0 / ( cell_size * cell_size ), mapping._inv_cell_measure );
+    for ( int d = 0; d < 2; ++d )
+    {
+        EXPECT_EQ( num_cell, mapping._global_num_cell[d] );
+        EXPECT_EQ( periodic[d], mapping._periodic[d] );
+    }
+
+    // Check grid.
+    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_mesh = global_grid.globalMesh();
+
+    EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
+    EXPECT_EQ( global_mesh.lowCorner( 1 ), 0.0 );
+
+    EXPECT_EQ( global_mesh.highCorner( 0 ), num_cell );
+    EXPECT_EQ( global_mesh.highCorner( 1 ), num_cell );
+
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 0 ), num_cell );
+    EXPECT_EQ( global_grid.globalNumEntity( Cajita::Cell(), 1 ), num_cell );
+
+    EXPECT_TRUE( global_grid.isPeriodic( 0 ) );
+    EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
+
+    auto local_grid = manager->mesh().localGrid();
+    EXPECT_EQ( local_grid->haloCellWidth(), 1 );
+
+    // Check mapping.
+    auto ghosted_cells = local_grid->indexSpace(
+        Cajita::Ghost(), Cajita::Cell(), Cajita::Local() );
+    auto local_mesh = Cajita::createLocalMesh<TEST_MEMSPACE>( *local_grid );
+    Kokkos::View<double** [2], TEST_MEMSPACE> cell_forward_map(
+        "cell_forward_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<double** [2], TEST_MEMSPACE> cell_reverse_map(
+        "cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<bool**, TEST_MEMSPACE> cell_map_success(
+        "cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<double** [2], TEST_MEMSPACE> default_cell_reverse_map(
+        "default_cell_reverse_map", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Kokkos::View<bool**, TEST_MEMSPACE> default_cell_map_success(
+        "default_cell_reverse_map_success", ghosted_cells.extent( Dim::I ),
+        ghosted_cells.extent( Dim::J ) );
+    Cajita::grid_parallel_for(
+        "check_mapping", TEST_EXECSPACE{}, ghosted_cells,
+        KOKKOS_LAMBDA( const int i, const int j ) {
+            // Map to physical frame.
+            LinearAlgebra::Vector<double, 2> cell_coords;
+            int ijk[2] = { i, j };
+            local_mesh.coordinates( Cajita::Cell{}, ijk, cell_coords.data() );
+            LinearAlgebra::VectorView<double, 2> phys_coords(
+                &cell_forward_map( i, j, 0 ), cell_forward_map.stride( 2 ) );
+            CurvilinearMeshMapping<mapping_type>::mapToPhysicalFrame(
+                mapping, cell_coords, phys_coords );
+
+            // Map to reference frame.
+            LinearAlgebra::VectorView<double, 2> ref_coords(
+                &cell_reverse_map( i, j, 0 ), cell_reverse_map.stride( 2 ) );
+            ref_coords = { cell_coords( Dim::I ) - 0.1,
+                           cell_coords( Dim::J ) - 0.1 };
+            cell_map_success( i, j ) =
+                CurvilinearMeshMapping<mapping_type>::mapToReferenceFrame(
+                    mapping, phys_coords, ref_coords );
+
+            // Default map to reference frame.
+            LinearAlgebra::VectorView<double, 2> default_ref_coords(
+                &default_cell_reverse_map( i, j, 0 ),
+                default_cell_reverse_map.stride( 2 ) );
+            default_ref_coords = { cell_coords( Dim::I ) - 0.1,
+                                   cell_coords( Dim::J ) - 0.1 };
+            default_cell_map_success( i, j ) = DefaultCurvilinearMeshMapping<
+                mapping_type>::mapToReferenceFrame( mapping, phys_coords,
+                                                    default_ref_coords );
+        } );
+
+    auto forward_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_forward_map );
+    auto reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_reverse_map );
+    auto map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, cell_map_success );
+    auto default_reverse_map_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_reverse_map );
+    auto default_map_success_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace{}, default_cell_map_success );
+
+    auto global_offset_i =
+        local_grid->globalGrid().globalOffset( Dim::I ) - halo_width;
+    auto global_offset_j =
+        local_grid->globalGrid().globalOffset( Dim::J ) - halo_width;
+
+    for ( int i = ghosted_cells.min( Dim::I ); i < ghosted_cells.max( Dim::I );
+          ++i )
+        for ( int j = ghosted_cells.min( Dim::J );
+              j < ghosted_cells.max( Dim::J ); ++j )
+        {
+            EXPECT_FLOAT_EQ( cell_size * ( global_offset_i + i + 0.5 ) +
+                                 global_box[0],
+                             forward_map_h( i, j, Dim::I ) );
+            EXPECT_FLOAT_EQ( cell_size * ( global_offset_j + j + 0.5 ) +
+                                 global_box[1],
+                             forward_map_h( i, j, Dim::J ) );
+
+            EXPECT_TRUE( map_success_h( i, j ) );
+
+            EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                             reverse_map_h( i, j, Dim::I ) );
+            EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                             reverse_map_h( i, j, Dim::J ) );
+
+            EXPECT_TRUE( default_map_success_h( i, j ) );
+
+            EXPECT_FLOAT_EQ( global_offset_i + i + 0.5,
+                             default_reverse_map_h( i, j, Dim::I ) );
+            EXPECT_FLOAT_EQ( global_offset_j + j + 0.5,
+                             default_reverse_map_h( i, j, Dim::J ) );
+        }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, mapping_test_3d ) { mappingTest3d(); }
+
+TEST( TEST_CATEGORY, mapping_test_2d ) { mappingTest2d(); }
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test


### PR DESCRIPTION
This PR adds an interface for general curvilinear mesh in which a mapping function is defined to map from the global physical frame to a global logical frame. This interface is represented by `CurvilinearMeshMapping` which describes all of the functionality needed to compute reference and logical mappings as well as the transformation metrics (e.g. Jacobians). A `CurvilinearMesh` is then built by composing a `Cajita::UniformMesh` in the logical frame and providing access to the mapping function on the device. A default implementation of some mapping functions are provided - particularly for the reference frame mapping in which a Newton method is used.

Two implementations of the mapping interface are provided and more can be added in the future. A uniform Cartesian mapping is given for performance while a bilinear mesh mapping is given to enable general grids and R-adaptivity. In the future we could add things like cylindrical or spherical coordinates. The bilinear mesh mapping relies on knowing the node coordinates as a separate field and has a generator interface which allows one to have different ways to create the coordinates. A default implementation of this is initialization to a uniform grid. In the future we could load a mesh externally.

- The unit tests check the mapping functions for each of the provided mappings. 
- I also updated a few unit tests to handle the recent Cajita changes for the boundary halo.
- The cajita boundary halo actually lets us get rid of the weird internal padding we were doing on non-periodic boundaries so now the input halo width is just the biggest halo that you need. This could be for particle or grid operations. Note that halo widths for the communication options can always be set to less-than-or-equal-to the allocated grid halo width.
- Batched linear algebra was updated so the determinant can be reused for matrix inversions.

Note: `UniformMesh` and `AdaptiveMesh` will eventually be deprecated/removed in favor of the curvilinear mesh. `CurvilinearMesh` will then become the main single block dense mesh class.