### PR TITLE
2D Grid Operator

### DIFF
--- a/src/Picasso_BilinearMeshMapping.hpp
+++ b/src/Picasso_BilinearMeshMapping.hpp
@@ -371,16 +371,18 @@ auto createBilinearMesh( MemorySpace, Generator generator, const int halo_width,
     auto manager = createFieldManager( mesh );
 
     // Add a node coordinates field to the manager.
-    manager->add( FieldLocation::Node{}, Field::PhysicalPosition{} );
+    manager->add( FieldLocation::Node{},
+                  Field::PhysicalPosition<NumSpaceDim>{} );
 
     // Assign coordinates to the mapping.
-    mapping->setLocalNodeCoordinates(
-        manager->view( FieldLocation::Node{}, Field::PhysicalPosition{} ) );
+    mapping->setLocalNodeCoordinates( manager->view(
+        FieldLocation::Node{}, Field::PhysicalPosition<NumSpaceDim>{} ) );
 
     // Generate the coordinates.
     BilinearMeshGenerator<Generator>::createLocalNodeCoordinates(
-        generator, *( manager->array( FieldLocation::Node{},
-                                      Field::PhysicalPosition{} ) ) );
+        generator,
+        *( manager->array( FieldLocation::Node{},
+                           Field::PhysicalPosition<NumSpaceDim>{} ) ) );
 
     return manager;
 }

--- a/src/Picasso_FieldManager.hpp
+++ b/src/Picasso_FieldManager.hpp
@@ -89,12 +89,15 @@ class FieldManager
         // The mesh is adaptive so add the physical position of its nodes as a
         // field.
         auto key =
-            createKey( FieldLocation::Node(), Field::PhysicalPosition() );
-        auto handle = std::make_shared<
-            FieldHandle<FieldLocation::Node, Field::PhysicalPosition, Mesh>>();
+            createKey( FieldLocation::Node(),
+                       Field::PhysicalPosition<mesh_type::num_space_dim>() );
+        auto handle = std::make_shared<FieldHandle<
+            FieldLocation::Node,
+            Field::PhysicalPosition<mesh_type::num_space_dim>, Mesh>>();
         handle->array = _mesh->nodes();
         handle->halo =
-            Cajita::createHalo<typename Field::PhysicalPosition::value_type,
+            Cajita::createHalo<typename Field::PhysicalPosition<
+                                   mesh_type::num_space_dim>::value_type,
                                typename Mesh::memory_space>(
                 *( handle->array->layout() ),
                 Cajita::NodeHaloPattern<Mesh::num_space_dim>() );
@@ -102,7 +105,7 @@ class FieldManager
     }
 
     // Get the mesh.
-    const Mesh& mesh() const { return *_mesh; }
+    std::shared_ptr<Mesh> mesh() const { return _mesh; }
 
     // Add a field. The field will be allocated and a halo created if it does
     // not already exist.

--- a/src/Picasso_FieldTypes.hpp
+++ b/src/Picasso_FieldTypes.hpp
@@ -77,6 +77,24 @@ struct FieldViewTuple
 
     Views _views;
 
+    // Access by layout.
+    template <class Layout>
+    KOKKOS_INLINE_FUNCTION const auto& get( Layout ) const
+    {
+        return Cabana::get<TypeIndexer<
+            FieldLayout<typename Layout::location, typename Layout::tag>,
+            Layouts...>::index>( _views );
+    }
+
+    template <class Layout>
+    KOKKOS_INLINE_FUNCTION auto& get( Layout )
+    {
+        return Cabana::get<TypeIndexer<
+            FieldLayout<typename Layout::location, typename Layout::tag>,
+            Layouts...>::index>( _views );
+    }
+
+    // Access by location and tag.
     template <class Location, class FieldTag>
     KOKKOS_INLINE_FUNCTION const auto& get( Location, FieldTag ) const
     {
@@ -491,12 +509,14 @@ auto createViewWrapper(
 //---------------------------------------------------------------------------//
 // Fields
 //---------------------------------------------------------------------------//
-struct PhysicalPosition : Vector<double, 3>
+template <std::size_t NumSpaceDim>
+struct PhysicalPosition : Vector<double, NumSpaceDim>
 {
     static std::string label() { return "physical_position"; }
 };
 
-struct LogicalPosition : Vector<double, 3>
+template <std::size_t NumSpaceDim>
+struct LogicalPosition : Vector<double, NumSpaceDim>
 {
     static std::string label() { return "logical_position"; }
 };

--- a/src/Picasso_ParticleList.hpp
+++ b/src/Picasso_ParticleList.hpp
@@ -274,8 +274,8 @@ class ParticleList
     {
         return ParticleCommunication::redistribute(
             *( _mesh->localGrid() ), _mesh->minimumHaloWidth(),
-            this->slice( Field::LogicalPosition() ), _aosoa,
-            force_redistribute );
+            this->slice( Field::LogicalPosition<mesh_type::num_space_dim>() ),
+            _aosoa, force_redistribute );
     }
 
   private:

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -169,7 +169,8 @@ Picasso_add_tests(MPI NAMES
   UniformMesh
   AdaptiveMesh
   FieldManager
-  GridOperator
+  GridOperator3d
+  GridOperator2d
   ParticleInterpolation
   LevelSetRedistance
   ParticleLevelSet)

--- a/unit_test/tstBilinearMeshMapping.hpp
+++ b/unit_test/tstBilinearMeshMapping.hpp
@@ -48,7 +48,7 @@ void mappingTest3d()
                                        MPI_COMM_WORLD, ranks_per_dim );
 
     // Check the mapping.
-    auto mapping = manager->mesh().mapping();
+    auto mapping = manager->mesh()->mapping();
     using mapping_type = decltype( mapping );
     for ( int d = 0; d < 3; ++d )
     {
@@ -57,7 +57,7 @@ void mappingTest3d()
     }
 
     // Check grid.
-    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_grid = manager->mesh()->localGrid()->globalGrid();
     const auto& global_mesh = global_grid.globalMesh();
 
     EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
@@ -76,7 +76,7 @@ void mappingTest3d()
     EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
     EXPECT_TRUE( global_grid.isPeriodic( 2 ) );
 
-    auto local_grid = manager->mesh().localGrid();
+    auto local_grid = manager->mesh()->localGrid();
     EXPECT_EQ( local_grid->haloCellWidth(), 1 );
 
     // Give a bad guess that is still in the local domain to test the ability
@@ -218,7 +218,7 @@ void mappingTest2d()
                                        MPI_COMM_WORLD, ranks_per_dim );
 
     // Check the mapping.
-    auto mapping = manager->mesh().mapping();
+    auto mapping = manager->mesh()->mapping();
     using mapping_type = decltype( mapping );
     for ( int d = 0; d < 2; ++d )
     {
@@ -227,7 +227,7 @@ void mappingTest2d()
     }
 
     // Check grid.
-    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_grid = manager->mesh()->localGrid()->globalGrid();
     const auto& global_mesh = global_grid.globalMesh();
 
     EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
@@ -242,7 +242,7 @@ void mappingTest2d()
     EXPECT_TRUE( global_grid.isPeriodic( 0 ) );
     EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
 
-    auto local_grid = manager->mesh().localGrid();
+    auto local_grid = manager->mesh()->localGrid();
     EXPECT_EQ( local_grid->haloCellWidth(), 1 );
 
     // Give a bad guess that is still in the local domain to test the ability

--- a/unit_test/tstFacetGeometry.hpp
+++ b/unit_test/tstFacetGeometry.hpp
@@ -491,7 +491,7 @@ struct LocateFunctor
         float xf[3] = { float( x[0] ), float( x[1] ), float( x[2] ) };
         for ( int d = 0; d < 3; ++d )
         {
-            get( p, Field::PhysicalPosition(), d ) = x[d];
+            get( p, Field::PhysicalPosition<3>(), d ) = x[d];
         }
         auto volume_id = FacetGeometryOps::locatePoint( xf, geom );
         get( p, Field::VolumeId() ) = volume_id;
@@ -515,7 +515,7 @@ void initExample()
         parser.propertyTree(), global_box, minimum_halo_size, MPI_COMM_WORLD );
 
     using list_type = ParticleList<UniformMesh<TEST_MEMSPACE>,
-                                   Field::PhysicalPosition, Field::VolumeId>;
+                                   Field::PhysicalPosition<3>, Field::VolumeId>;
     list_type particles( "particles", mesh );
 
     FacetGeometry<TEST_MEMSPACE> geometry( parser.propertyTree(),
@@ -529,7 +529,7 @@ void initExample()
 #ifdef Picasso_ENABLE_SILO
     SiloParticleWriter::writeTimeStep(
         mesh->localGrid()->globalGrid(), 0, 0.0,
-        particles.slice( Field::PhysicalPosition() ),
+        particles.slice( Field::PhysicalPosition<3>() ),
         particles.slice( Field::VolumeId() ) );
 #endif
 }

--- a/unit_test/tstFieldManager.hpp
+++ b/unit_test/tstFieldManager.hpp
@@ -162,7 +162,8 @@ void adaptiveTest()
     FieldManager<AdaptiveMesh<TEST_MEMSPACE>> fm( mesh );
 
     // Check that the adaptive mesh coordinates got loaded.
-    auto nodes = fm.array( FieldLocation::Node(), Field::PhysicalPosition() );
+    auto nodes =
+        fm.array( FieldLocation::Node(), Field::PhysicalPosition<3>() );
     auto host_coords = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
                                                             nodes->view() );
     auto local_mesh = Cajita::createLocalMesh<TEST_EXECSPACE>(

--- a/unit_test/tstGridOperator2d.hpp
+++ b/unit_test/tstGridOperator2d.hpp
@@ -1,0 +1,196 @@
+/****************************************************************************
+ * Copyright (c) 2021 by the Picasso authors                                *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Picasso library. Picasso is distributed under a *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Picasso_FieldManager.hpp>
+#include <Picasso_FieldTypes.hpp>
+#include <Picasso_GridOperator.hpp>
+#include <Picasso_InputParser.hpp>
+#include <Picasso_ParticleInit.hpp>
+#include <Picasso_ParticleInterpolation.hpp>
+#include <Picasso_ParticleList.hpp>
+#include <Picasso_Types.hpp>
+#include <Picasso_UniformCartesianMeshMapping.hpp>
+
+#include <Cajita.hpp>
+
+#include <Cabana_Core.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Picasso;
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+// Field tags.
+struct FooP : Field::Vector<double, 2>
+{
+    static std::string label() { return "foo_p"; }
+};
+
+struct FooIn : Field::Vector<double, 2>
+{
+    static std::string label() { return "foo_in"; }
+};
+
+struct FooOut : Field::Vector<double, 2>
+{
+    static std::string label() { return "foo_out"; }
+};
+
+struct BarP : Field::Scalar<double>
+{
+    static std::string label() { return "bar_p"; }
+};
+
+struct BarIn : Field::Scalar<double>
+{
+    static std::string label() { return "bar_in"; }
+};
+
+struct BarOut : Field::Scalar<double>
+{
+    static std::string label() { return "bar_out"; }
+};
+
+struct Baz : Field::Tensor<double, 2, 2>
+{
+    static std::string label() { return "baz"; }
+};
+
+//---------------------------------------------------------------------------//
+// Grid operation.
+struct GridFunc
+{
+    struct Tag
+    {
+    };
+
+    template <class LocalMeshType, class GatherDependencies,
+              class ScatterDependencies, class LocalDependencies>
+    KOKKOS_INLINE_FUNCTION void operator()(
+        Tag, const LocalMeshType&, const GatherDependencies& gather_deps,
+        const ScatterDependencies& scatter_deps,
+        const LocalDependencies& local_deps, const int i, const int j ) const
+    {
+        // Get input dependencies.
+        auto foo_in = gather_deps.get( FieldLocation::Cell(), FooIn() );
+        auto bar_in = gather_deps.get( FieldLocation::Cell(), BarIn() );
+
+        // Get output dependencies.
+        auto foo_out = scatter_deps.get( FieldLocation::Cell(), FooOut() );
+        auto bar_out = scatter_deps.get( FieldLocation::Cell(), BarOut() );
+
+        // Get scatter view accessors.
+        auto foo_out_access = foo_out.access();
+        auto bar_out_access = bar_out.access();
+
+        // Get local dependencies.
+        auto baz = local_deps.get( FieldLocation::Cell(), Baz() );
+
+        // Set up the local dependency to be the identity.
+        baz( i, j ) = { { 1.0, 0.0 }, { 0.0, 1.0 } };
+
+        // Assign foo_out - build a point-wise expression to do this.
+        auto baz_t_foo_in_t_2 =
+            baz( i, j ) * ( foo_in( i, j ) + foo_in( i, j ) );
+        for ( int d = 0; d < 2; ++d )
+            foo_out_access( i, j, d ) += baz_t_foo_in_t_2( d ) + i + j;
+
+        // Assign the bar_out - use mixture of field dimension indices
+        // or direct ijk access.
+        bar_out_access( i, j, 0 ) += bar_in( i, j, 0 ) + bar_in( i, j ) + i + j;
+    }
+};
+
+//---------------------------------------------------------------------------//
+void gatherScatterTest()
+{
+    // Global bounding box.
+    double cell_size = 0.23;
+    std::array<int, 2> global_num_cell = { 43, 22 };
+    std::array<double, 2> global_low_corner = { 1.2, 2.3 };
+    std::array<double, 2> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1] };
+    Kokkos::Array<bool, 2> periodic = { false, false };
+    int comm_size = -1;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { comm_size, 1 };
+
+    // Get inputs for mesh.
+    Kokkos::Array<double, 4> global_box = {
+        global_low_corner[0], global_low_corner[1], global_high_corner[0],
+        global_high_corner[1] };
+    int minimum_halo_size = 0;
+
+    // Make mesh and field manager.
+    auto fm = createUniformCartesianMesh(
+        TEST_MEMSPACE{}, cell_size, global_box, periodic, minimum_halo_size,
+        MPI_COMM_WORLD, ranks_per_dim );
+
+    // Make an operator.
+    using gather_deps =
+        GatherDependencies<FieldLayout<FieldLocation::Cell, FooIn>,
+                           FieldLayout<FieldLocation::Cell, BarIn>>;
+    using scatter_deps =
+        ScatterDependencies<FieldLayout<FieldLocation::Cell, FooOut>,
+                            FieldLayout<FieldLocation::Cell, BarOut>>;
+    using local_deps = LocalDependencies<FieldLayout<FieldLocation::Cell, Baz>>;
+    auto grid_op = createGridOperator( fm->mesh(), gather_deps(),
+                                       scatter_deps(), local_deps() );
+
+    // Setup the field manager.
+    grid_op->setup( *fm );
+
+    // Initialize gather fields.
+    Kokkos::deep_copy( fm->view( FieldLocation::Cell(), FooIn() ), 2.0 );
+    Kokkos::deep_copy( fm->view( FieldLocation::Cell(), BarIn() ), 3.0 );
+
+    // Initialiize scatter fields to wrong data to make sure they get reset to
+    // zero and then overwritten with the data we assign in the operator.
+    Kokkos::deep_copy( fm->view( FieldLocation::Cell(), FooOut() ), -1.1 );
+    Kokkos::deep_copy( fm->view( FieldLocation::Cell(), BarOut() ), -2.2 );
+
+    // Apply the grid operator. Use a tag.
+    GridFunc grid_func;
+    grid_op->apply( FieldLocation::Cell(), TEST_EXECSPACE(), *fm,
+                    GridFunc::Tag(), grid_func );
+
+    // Check the grid results.
+    auto foo_out_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), fm->view( FieldLocation::Cell(), FooOut() ) );
+    auto bar_out_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), fm->view( FieldLocation::Cell(), BarOut() ) );
+    Kokkos::deep_copy( foo_out_host,
+                       fm->view( FieldLocation::Cell(), FooOut() ) );
+    Kokkos::deep_copy( bar_out_host,
+                       fm->view( FieldLocation::Cell(), BarOut() ) );
+    Cajita::grid_parallel_for(
+        "check_grid_out", Kokkos::DefaultHostExecutionSpace(),
+        *( fm->mesh()->localGrid() ), Cajita::Own(), Cajita::Cell(),
+        KOKKOS_LAMBDA( const int i, const int j ) {
+            for ( int d = 0; d < 2; ++d )
+                EXPECT_EQ( foo_out_host( i, j, d ), 4.0 + i + j );
+            EXPECT_EQ( bar_out_host( i, j, 0 ), 6.0 + i + j );
+        } );
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, gather_scatter_test ) { gatherScatterTest(); }
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/unit_test/tstGridOperator3d.hpp
+++ b/unit_test/tstGridOperator3d.hpp
@@ -95,7 +95,7 @@ struct ParticleFunc
         // Zero-order cell interpolant.
         auto spline = createSpline(
             FieldLocation::Cell(), InterpolationOrder<0>(), local_mesh,
-            get( particle, Field::LogicalPosition() ), SplineValue() );
+            get( particle, Field::LogicalPosition<3>() ), SplineValue() );
 
         // Interpolate to the particles.
         G2P::value( spline, foo_in, foop );
@@ -182,7 +182,7 @@ void gatherScatterTest()
 
     // Make a particle list.
     using list_type = ParticleList<UniformMesh<TEST_MEMSPACE>,
-                                   Field::LogicalPosition, FooP, BarP>;
+                                   Field::LogicalPosition<3>, FooP, BarP>;
     list_type particles( "test_particles", mesh );
     using particle_type = typename list_type::particle_type;
 
@@ -191,7 +191,7 @@ void gatherScatterTest()
         KOKKOS_LAMBDA( const double x[3], const double, particle_type& p )
     {
         for ( int d = 0; d < 3; ++d )
-            get( p, Field::LogicalPosition(), d ) = x[d];
+            get( p, Field::LogicalPosition<3>(), d ) = x[d];
         return true;
     };
 

--- a/unit_test/tstParticleInterpolation.hpp
+++ b/unit_test/tstParticleInterpolation.hpp
@@ -78,7 +78,7 @@ struct ScalarValueP2G
         // Node Interpolant
         auto spline = createSpline(
             FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
-            get( particle, Field::LogicalPosition() ), SplineValue() );
+            get( particle, Field::LogicalPosition<3>() ), SplineValue() );
 
         // Interpolate to grid.
         P2G::value( spline, particle_scalar, node_scalar );
@@ -106,7 +106,7 @@ struct VectorValueP2G
         // Node Interpolant
         auto spline = createSpline(
             FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
-            get( particle, Field::LogicalPosition() ), SplineValue() );
+            get( particle, Field::LogicalPosition<3>() ), SplineValue() );
 
         // Interpolate to grid.
         P2G::value( spline, particle_vector, node_vector );
@@ -132,10 +132,10 @@ struct ScalarGradientP2G
         auto particle_scalar = get( particle, ParticleScalar() );
 
         // Node Interpolant
-        auto spline =
-            createSpline( FieldLocation::Node(), InterpolationOrder<1>(),
-                          local_mesh, get( particle, Field::LogicalPosition() ),
-                          SplineValue(), SplineGradient() );
+        auto spline = createSpline(
+            FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
+            get( particle, Field::LogicalPosition<3>() ), SplineValue(),
+            SplineGradient() );
 
         // Interpolate to grid.
         P2G::gradient( spline, particle_scalar, node_vector );
@@ -161,10 +161,10 @@ struct VectorDivergenceP2G
         auto particle_vector = get( particle, ParticleVector() );
 
         // Node Interpolant
-        auto spline =
-            createSpline( FieldLocation::Node(), InterpolationOrder<1>(),
-                          local_mesh, get( particle, Field::LogicalPosition() ),
-                          SplineValue(), SplineGradient() );
+        auto spline = createSpline(
+            FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
+            get( particle, Field::LogicalPosition<3>() ), SplineValue(),
+            SplineGradient() );
 
         // Interpolate to grid.
         P2G::divergence( spline, particle_vector, node_scalar );
@@ -190,10 +190,10 @@ struct TensorDivergenceP2G
         auto particle_tensor = get( particle, ParticleTensor() );
 
         // Node Interpolant
-        auto spline =
-            createSpline( FieldLocation::Node(), InterpolationOrder<1>(),
-                          local_mesh, get( particle, Field::LogicalPosition() ),
-                          SplineValue(), SplineGradient() );
+        auto spline = createSpline(
+            FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
+            get( particle, Field::LogicalPosition<3>() ), SplineValue(),
+            SplineGradient() );
 
         // Interpolate to grid.
         P2G::divergence( spline, particle_tensor, node_vector );
@@ -222,7 +222,7 @@ struct ScalarValueG2P
         // Node Interpolant
         auto spline = createSpline(
             FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
-            get( particle, Field::LogicalPosition() ), SplineValue() );
+            get( particle, Field::LogicalPosition<3>() ), SplineValue() );
 
         // Interpolate to grid.
         G2P::value( spline, node_scalar, particle_scalar );
@@ -251,7 +251,7 @@ struct VectorValueG2P
         // Node Interpolant
         auto spline = createSpline(
             FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
-            get( particle, Field::LogicalPosition() ), SplineValue() );
+            get( particle, Field::LogicalPosition<3>() ), SplineValue() );
 
         // Interpolate to grid.
         G2P::value( spline, node_vector, particle_vector );
@@ -278,10 +278,10 @@ struct ScalarGradientG2P
         auto particle_vector = get( particle, ParticleVector() );
 
         // Node Interpolant
-        auto spline =
-            createSpline( FieldLocation::Node(), InterpolationOrder<1>(),
-                          local_mesh, get( particle, Field::LogicalPosition() ),
-                          SplineValue(), SplineGradient() );
+        auto spline = createSpline(
+            FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
+            get( particle, Field::LogicalPosition<3>() ), SplineValue(),
+            SplineGradient() );
 
         // Interpolate to grid.
         G2P::gradient( spline, node_scalar, particle_vector );
@@ -308,10 +308,10 @@ struct VectorGradientG2P
         auto particle_tensor = get( particle, ParticleTensor() );
 
         // Node Interpolant
-        auto spline =
-            createSpline( FieldLocation::Node(), InterpolationOrder<1>(),
-                          local_mesh, get( particle, Field::LogicalPosition() ),
-                          SplineValue(), SplineGradient() );
+        auto spline = createSpline(
+            FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
+            get( particle, Field::LogicalPosition<3>() ), SplineValue(),
+            SplineGradient() );
 
         // Interpolate to grid.
         G2P::gradient( spline, node_vector, particle_tensor );
@@ -338,10 +338,10 @@ struct VectorDivergenceG2P
         auto& particle_scalar = get( particle, ParticleScalar() );
 
         // Node Interpolant
-        auto spline =
-            createSpline( FieldLocation::Node(), InterpolationOrder<1>(),
-                          local_mesh, get( particle, Field::LogicalPosition() ),
-                          SplineValue(), SplineGradient() );
+        auto spline = createSpline(
+            FieldLocation::Node(), InterpolationOrder<1>(), local_mesh,
+            get( particle, Field::LogicalPosition<3>() ), SplineValue(),
+            SplineGradient() );
 
         // Interpolate to grid.
         G2P::divergence( spline, node_vector, particle_scalar );
@@ -378,7 +378,7 @@ void interpolationTest()
 
     // Make a particle list.
     using list_type =
-        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition,
+        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition<3>,
                      ParticleScalar, ParticleVector, ParticleTensor>;
     list_type particles( "test_particles", mesh );
     using particle_type = typename list_type::particle_type;
@@ -388,7 +388,7 @@ void interpolationTest()
         KOKKOS_LAMBDA( const double x[3], const double, particle_type& p )
     {
         for ( int d = 0; d < 3; ++d )
-            get( p, Field::LogicalPosition(), d ) = x[d];
+            get( p, Field::LogicalPosition<3>(), d ) = x[d];
         return true;
     };
 

--- a/unit_test/tstParticleLevelSet.hpp
+++ b/unit_test/tstParticleLevelSet.hpp
@@ -48,8 +48,8 @@ struct LocateFunctor
         float xf[3] = { float( x[0] ), float( x[1] ), float( x[2] ) };
         for ( int d = 0; d < 3; ++d )
         {
-            get( p, Field::PhysicalPosition(), d ) = x[d];
-            get( p, Field::LogicalPosition(), d ) = x[d];
+            get( p, Field::PhysicalPosition<3>(), d ) = x[d];
+            get( p, Field::LogicalPosition<3>(), d ) = x[d];
         }
         auto volume_id = FacetGeometryOps::locatePoint( xf, geom );
         get( p, Field::Color() ) = volume_id;
@@ -80,7 +80,7 @@ void zalesaksTest( const std::string& filename )
     // Create particles.
     auto particles = createParticleList(
         "particles", mesh,
-        ParticleTraits<Field::PhysicalPosition, Field::LogicalPosition,
+        ParticleTraits<Field::PhysicalPosition<3>, Field::LogicalPosition<3>,
                        Field::Color, Field::CommRank>() );
 
     // Assign particles a color equal to the volume id in which they are
@@ -96,7 +96,7 @@ void zalesaksTest( const std::string& filename )
 #ifdef Picasso_ENABLE_SILO
     SiloParticleWriter::writeTimeStep(
         mesh->localGrid()->globalGrid(), 0, time,
-        particles->slice( Field::PhysicalPosition() ),
+        particles->slice( Field::PhysicalPosition<3>() ),
         particles->slice( Field::Color() ),
         particles->slice( Field::CommRank() ) );
 #endif
@@ -110,7 +110,7 @@ void zalesaksTest( const std::string& filename )
 
     // Compute the initial level set.
     level_set->estimateSignedDistance(
-        TEST_EXECSPACE(), particles->slice( Field::LogicalPosition() ) );
+        TEST_EXECSPACE(), particles->slice( Field::LogicalPosition<3>() ) );
     level_set->levelSet()->redistance( TEST_EXECSPACE() );
 
     // Write the initial level set.
@@ -126,8 +126,8 @@ void zalesaksTest( const std::string& filename )
     for ( int t = 0; t < num_step; ++t )
     {
         // Get slices.
-        auto xp = particles->slice( Field::PhysicalPosition() );
-        auto xl = particles->slice( Field::LogicalPosition() );
+        auto xp = particles->slice( Field::PhysicalPosition<3>() );
+        auto xl = particles->slice( Field::LogicalPosition<3>() );
         auto xr = particles->slice( Field::CommRank() );
 
         // Move the particles around the circle.
@@ -176,14 +176,14 @@ void zalesaksTest( const std::string& filename )
 #ifdef Picasso_ENABLE_SILO
         SiloParticleWriter::writeTimeStep(
             mesh->localGrid()->globalGrid(), t + 1, time,
-            particles->slice( Field::PhysicalPosition() ),
+            particles->slice( Field::PhysicalPosition<3>() ),
             particles->slice( Field::Color() ),
             particles->slice( Field::CommRank() ) );
 #endif
 
         // Compute the level set.
         level_set->estimateSignedDistance(
-            TEST_EXECSPACE(), particles->slice( Field::LogicalPosition() ) );
+            TEST_EXECSPACE(), particles->slice( Field::LogicalPosition<3>() ) );
         level_set->levelSet()->redistance( TEST_EXECSPACE() );
 
         // Write the level set.

--- a/unit_test/tstParticleList.hpp
+++ b/unit_test/tstParticleList.hpp
@@ -51,7 +51,7 @@ void particleTest()
 
     // Make a particle list.
     using list_type =
-        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition, Foo,
+        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition<3>, Foo,
                      Field::Color, Bar>;
 
     list_type particles( "test_particles", mesh );
@@ -63,7 +63,7 @@ void particleTest()
     EXPECT_EQ( particles.aosoa().size(), 10 );
 
     // Populate fields.
-    auto px = particles.slice( Field::LogicalPosition() );
+    auto px = particles.slice( Field::LogicalPosition<3>() );
     auto pm = particles.slice( Foo() );
     auto pc = particles.slice( Field::Color() );
     auto pf = particles.slice( Bar() );
@@ -107,7 +107,7 @@ void particleTest()
             typename list_type::particle_type particle( aosoa.getTuple( p ) );
 
             for ( int d = 0; d < 3; ++d )
-                get( particle, Field::LogicalPosition(), d ) += p + d;
+                get( particle, Field::LogicalPosition<3>(), d ) += p + d;
 
             get( particle, Foo() ) += p;
 
@@ -152,7 +152,7 @@ void particleViewTest()
 
     // Make a particle list.
     using list_type =
-        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition, Foo,
+        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition<3>, Foo,
                      Field::Color, Bar>;
 
     list_type particles( "test_particles", mesh );
@@ -164,7 +164,7 @@ void particleViewTest()
     EXPECT_EQ( particles.aosoa().size(), 10 );
 
     // Populate fields.
-    auto px = particles.slice( Field::LogicalPosition() );
+    auto px = particles.slice( Field::LogicalPosition<3>() );
     auto pm = particles.slice( Foo() );
     auto pc = particles.slice( Field::Color() );
     auto pf = particles.slice( Bar() );
@@ -213,7 +213,7 @@ void particleViewTest()
                                                              a );
 
             for ( int d = 0; d < 3; ++d )
-                get( particle, Field::LogicalPosition(), d ) += p + d;
+                get( particle, Field::LogicalPosition<3>(), d ) += p + d;
 
             get( particle, Foo() ) += p;
 
@@ -256,7 +256,7 @@ void linearAlgebraTest()
 
     // Make a particle list.
     using list_type =
-        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition, Foo,
+        ParticleList<UniformMesh<TEST_MEMSPACE>, Field::LogicalPosition<3>, Foo,
                      Field::Color, Bar>;
 
     list_type particles( "test_particles", mesh );
@@ -268,7 +268,7 @@ void linearAlgebraTest()
     EXPECT_EQ( particles.aosoa().size(), 10 );
 
     // Populate fields.
-    auto px = particles.slice( Field::LogicalPosition() );
+    auto px = particles.slice( Field::LogicalPosition<3>() );
     auto pm = particles.slice( Foo() );
     auto pc = particles.slice( Field::Color() );
     auto pf = particles.slice( Bar() );
@@ -316,7 +316,7 @@ void linearAlgebraTest()
             typename list_type::particle_view_type particle( aosoa.access( s ),
                                                              a );
 
-            auto px_v = get( particle, Field::LogicalPosition() );
+            auto px_v = get( particle, Field::LogicalPosition<3>() );
             for ( int d = 0; d < 3; ++d )
                 px_v( d ) += p + d;
 

--- a/unit_test/tstUniformCartesianMeshMapping.hpp
+++ b/unit_test/tstUniformCartesianMeshMapping.hpp
@@ -45,7 +45,7 @@ void mappingTest3d()
                                                MPI_COMM_WORLD, ranks_per_dim );
 
     // Check the mapping data.
-    auto mapping = manager->mesh().mapping();
+    auto mapping = manager->mesh()->mapping();
     using mapping_type = decltype( mapping );
     EXPECT_EQ( cell_size, mapping._cell_size );
     EXPECT_EQ( 1.0 / cell_size, mapping._inv_cell_size );
@@ -59,7 +59,7 @@ void mappingTest3d()
     }
 
     // Check grid.
-    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_grid = manager->mesh()->localGrid()->globalGrid();
     const auto& global_mesh = global_grid.globalMesh();
 
     EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
@@ -78,7 +78,7 @@ void mappingTest3d()
     EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
     EXPECT_TRUE( global_grid.isPeriodic( 2 ) );
 
-    auto local_grid = manager->mesh().localGrid();
+    auto local_grid = manager->mesh()->localGrid();
     EXPECT_EQ( local_grid->haloCellWidth(), 1 );
 
     // Check mapping.
@@ -209,7 +209,7 @@ void mappingTest2d()
                                                MPI_COMM_WORLD, ranks_per_dim );
 
     // Check the mapping data.
-    auto mapping = manager->mesh().mapping();
+    auto mapping = manager->mesh()->mapping();
     using mapping_type = decltype( mapping );
     EXPECT_EQ( cell_size, mapping._cell_size );
     EXPECT_EQ( 1.0 / cell_size, mapping._inv_cell_size );
@@ -222,7 +222,7 @@ void mappingTest2d()
     }
 
     // Check grid.
-    const auto& global_grid = manager->mesh().localGrid()->globalGrid();
+    const auto& global_grid = manager->mesh()->localGrid()->globalGrid();
     const auto& global_mesh = global_grid.globalMesh();
 
     EXPECT_EQ( global_mesh.lowCorner( 0 ), 0.0 );
@@ -237,7 +237,7 @@ void mappingTest2d()
     EXPECT_TRUE( global_grid.isPeriodic( 0 ) );
     EXPECT_FALSE( global_grid.isPeriodic( 1 ) );
 
-    auto local_grid = manager->mesh().localGrid();
+    auto local_grid = manager->mesh()->localGrid();
     EXPECT_EQ( local_grid->haloCellWidth(), 1 );
 
     // Check mapping.


### PR DESCRIPTION
This PR adds a 2D grid operator. Per #20 particles still need to be updated to 2D.

NOTE: A spatial dimension template has been added to `Field::PhysicalPosition` and `Field::LogicalPosition` to handle varying dimensions.