### PR TITLE
Fix scalar vectors/matrices

### DIFF
--- a/src/Picasso_BatchedLinearAlgebra.hpp
+++ b/src/Picasso_BatchedLinearAlgebra.hpp
@@ -352,6 +352,9 @@ struct Matrix
         typename std::enable_if<is_matrix<Expression>::value, int>::type = 0>
     KOKKOS_INLINE_FUNCTION Matrix( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -378,6 +381,9 @@ struct Matrix
         typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
         operator=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -393,6 +399,9 @@ struct Matrix
         typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
         operator+=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -408,6 +417,9 @@ struct Matrix
         typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
         operator-=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -532,6 +544,9 @@ struct Matrix<T, 1, 1>
         typename std::enable_if<is_matrix<Expression>::value, int>::type = 0>
     KOKKOS_INLINE_FUNCTION Matrix( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d = e( 0, 0 );
     }
 
@@ -541,6 +556,9 @@ struct Matrix<T, 1, 1>
         typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
         operator=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d = e( 0, 0 );
         return *this;
     }
@@ -551,6 +569,9 @@ struct Matrix<T, 1, 1>
         typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
         operator+=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d += e( 0, 0 );
         return *this;
     }
@@ -561,6 +582,9 @@ struct Matrix<T, 1, 1>
         typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
         operator-=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d -= e( 0, 0 );
         return *this;
     }
@@ -653,6 +677,9 @@ struct MatrixView
         typename std::enable_if<is_matrix<Expression>::value, MatrixView&>::type
         operator=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -668,6 +695,9 @@ struct MatrixView
         typename std::enable_if<is_matrix<Expression>::value, MatrixView&>::type
         operator+=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -683,6 +713,9 @@ struct MatrixView
         typename std::enable_if<is_matrix<Expression>::value, MatrixView&>::type
         operator-=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         for ( int i = 0; i < M; ++i )
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
@@ -820,6 +853,9 @@ struct Vector
         typename std::enable_if<is_vector<Expression>::value, int>::type = 0>
     KOKKOS_INLINE_FUNCTION Vector( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif
@@ -844,6 +880,9 @@ struct Vector
         typename std::enable_if<is_vector<Expression>::value, Vector&>::type
         operator=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif
@@ -858,6 +897,9 @@ struct Vector
         typename std::enable_if<is_vector<Expression>::value, Vector&>::type
         operator+=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif
@@ -872,6 +914,9 @@ struct Vector
         typename std::enable_if<is_vector<Expression>::value, Vector&>::type
         operator-=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif
@@ -978,6 +1023,9 @@ struct Vector<T, 1>
         typename std::enable_if<is_vector<Expression>::value, int>::type = 0>
     KOKKOS_INLINE_FUNCTION Vector( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d = e( 0 );
     }
 
@@ -987,6 +1035,9 @@ struct Vector<T, 1>
         typename std::enable_if<is_vector<Expression>::value, Vector&>::type
         operator=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d = e( 0 );
         return *this;
     }
@@ -997,6 +1048,9 @@ struct Vector<T, 1>
         typename std::enable_if<is_vector<Expression>::value, Vector&>::type
         operator+=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d += e( 0 );
         return *this;
     }
@@ -1007,6 +1061,9 @@ struct Vector<T, 1>
         typename std::enable_if<is_vector<Expression>::value, Vector&>::type
         operator-=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
         _d -= e( 0 );
         return *this;
     }
@@ -1104,6 +1161,9 @@ struct VectorView
         typename std::enable_if<is_vector<Expression>::value, VectorView&>::type
         operator=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif
@@ -1118,6 +1178,9 @@ struct VectorView
         typename std::enable_if<is_vector<Expression>::value, VectorView&>::type
         operator+=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif
@@ -1132,6 +1195,9 @@ struct VectorView
         typename std::enable_if<is_vector<Expression>::value, VectorView&>::type
         operator-=( const Expression& e )
     {
+        static_assert( Expression::extent_0 == extent_0, "Extents must match" );
+        static_assert( Expression::extent_1 == extent_1, "Extents must match" );
+
 #if defined( KOKKOS_ENABLE_PRAGMA_UNROLL )
 #pragma unroll
 #endif

--- a/src/Picasso_BatchedLinearAlgebra.hpp
+++ b/src/Picasso_BatchedLinearAlgebra.hpp
@@ -526,6 +526,45 @@ struct Matrix<T, 1, 1>
     {
     }
 
+    // Deep copy constructor. Triggers expression evaluation.
+    template <
+        class Expression,
+        typename std::enable_if<is_matrix<Expression>::value, int>::type = 0>
+    KOKKOS_INLINE_FUNCTION Matrix( const Expression& e )
+    {
+        _d = e( 0, 0 );
+    }
+
+    // Assignment operator. Triggers expression evaluation.
+    template <class Expression>
+    KOKKOS_INLINE_FUNCTION
+        typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
+        operator=( const Expression& e )
+    {
+        _d = e( 0, 0 );
+        return *this;
+    }
+
+    // Addition assignment operator. Triggers expression evaluation.
+    template <class Expression>
+    KOKKOS_INLINE_FUNCTION
+        typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
+        operator+=( const Expression& e )
+    {
+        _d += e( 0, 0 );
+        return *this;
+    }
+
+    // Subtraction assignment operator. Triggers expression evaluation.
+    template <class Expression>
+    KOKKOS_INLINE_FUNCTION
+        typename std::enable_if<is_matrix<Expression>::value, Matrix&>::type
+        operator-=( const Expression& e )
+    {
+        _d -= e( 0, 0 );
+        return *this;
+    }
+
     // Scalar value assignment.
     KOKKOS_INLINE_FUNCTION
     Matrix& operator=( const T value )
@@ -931,6 +970,45 @@ struct Vector<T, 1>
     Vector( const T value )
         : _d( value )
     {
+    }
+
+    // Deep copy constructor. Triggers expression evaluation.
+    template <
+        class Expression,
+        typename std::enable_if<is_vector<Expression>::value, int>::type = 0>
+    KOKKOS_INLINE_FUNCTION Vector( const Expression& e )
+    {
+        _d = e( 0 );
+    }
+
+    // Deep copy assignment operator. Triggers expression evaluation.
+    template <class Expression>
+    KOKKOS_INLINE_FUNCTION
+        typename std::enable_if<is_vector<Expression>::value, Vector&>::type
+        operator=( const Expression& e )
+    {
+        _d = e( 0 );
+        return *this;
+    }
+
+    // Addition assignment operator. Triggers expression evaluation.
+    template <class Expression>
+    KOKKOS_INLINE_FUNCTION
+        typename std::enable_if<is_vector<Expression>::value, Vector&>::type
+        operator+=( const Expression& e )
+    {
+        _d += e( 0 );
+        return *this;
+    }
+
+    // Subtraction assignment operator. Triggers expression evaluation.
+    template <class Expression>
+    KOKKOS_INLINE_FUNCTION
+        typename std::enable_if<is_vector<Expression>::value, Vector&>::type
+        operator-=( const Expression& e )
+    {
+        _d -= e( 0 );
+        return *this;
     }
 
     // Scalar value assignment.

--- a/unit_test/tstBatchedLinearAlgebra.hpp
+++ b/unit_test/tstBatchedLinearAlgebra.hpp
@@ -241,6 +241,17 @@ void matrixTest()
     for ( int i = 0; i < 2; ++i )
         for ( int j = 0; j < 3; ++j )
             EXPECT_DOUBLE_EQ( g( i, j ), 32.3 );
+
+    // 1x1 matrix test.
+    LinearAlgebra::Matrix<double, 1, 1> obo = 3.2;
+    obo += ~obo * obo;
+    EXPECT_DOUBLE_EQ( 13.44, obo( 0, 0 ) );
+    obo -= ~obo * obo;
+    EXPECT_DOUBLE_EQ( -167.1936, obo( 0, 0 ) );
+    obo = 12.0;
+    EXPECT_DOUBLE_EQ( 12.0, obo( 0, 0 ) );
+    LinearAlgebra::Matrix<double, 1, 1> obo2 = ~obo * obo;
+    EXPECT_DOUBLE_EQ( 144.0, obo2( 0, 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -349,6 +360,17 @@ void vectorTest()
     LinearAlgebra::deepCopy( w, q );
     for ( int i = 0; i < 3; ++i )
         EXPECT_DOUBLE_EQ( w( i ), 32.3 );
+
+    // Size 1 vector test.
+    LinearAlgebra::Vector<double, 1> sov = 3.2;
+    sov += ~sov * sov;
+    EXPECT_DOUBLE_EQ( 13.44, sov( 0 ) );
+    sov -= ~sov * sov;
+    EXPECT_DOUBLE_EQ( -167.1936, sov( 0 ) );
+    sov = 12.0;
+    EXPECT_DOUBLE_EQ( 12.0, sov( 0 ) );
+    LinearAlgebra::Vector<double, 1> sov2 = ~sov * sov;
+    EXPECT_DOUBLE_EQ( 144.0, sov2( 0 ) );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Some copy/assignment operators were not implemented for the scalar overloads of vectors and matrices. These exist because they provide the scalar conversion operator.