### PR TITLE
Array-based point-wise access operators for view wrappers

### DIFF
--- a/src/Picasso_FieldTypes.hpp
+++ b/src/Picasso_FieldTypes.hpp
@@ -311,6 +311,8 @@ struct ScalarViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, linear_algebra_type&>
     operator()( const int i0, const int i1, const int i2 ) const
     {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, i2, 0 );
     }
 
@@ -318,7 +320,28 @@ struct ScalarViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, linear_algebra_type&>
     operator()( const int i0, const int i1 ) const
     {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, 0 );
+    }
+
+    // Access data through point-wise array-based index arguments.
+    template <int VR = view_rank>
+    KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, linear_algebra_type&>
+    operator()( const int i[3] ) const
+    {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
+        return _v( i[0], i[1], i[2], 0 );
+    }
+
+    template <int VR = view_rank>
+    KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, linear_algebra_type&>
+    operator()( const int i[2] ) const
+    {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
+        return _v( i[0], i[1], 0 );
     }
 
     // Access the view data through full index arguments.
@@ -326,6 +349,8 @@ struct ScalarViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, value_type&>
     operator()( const int i0, const int i1, const int i2, const int ) const
     {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, i2, 0 );
     }
 
@@ -333,6 +358,8 @@ struct ScalarViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, value_type&>
     operator()( const int i0, const int i1, const int ) const
     {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, 0 );
     }
 };
@@ -377,6 +404,8 @@ struct VectorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, linear_algebra_type>
     operator()( const int i0, const int i1, const int i2 ) const
     {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return linear_algebra_type( &_v( i0, i1, i2, 0 ), _v.stride( 3 ) );
     }
 
@@ -384,7 +413,30 @@ struct VectorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, linear_algebra_type>
     operator()( const int i0, const int i1 ) const
     {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return linear_algebra_type( &_v( i0, i1, 0 ), _v.stride( 2 ) );
+    }
+
+    // Access the view data as a vector through point-wise array-based index
+    // arguments.
+    template <int VR = view_rank>
+    KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, linear_algebra_type>
+    operator()( const int i[3] ) const
+    {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
+        return linear_algebra_type( &_v( i[0], i[1], i[2], 0 ),
+                                    _v.stride( 3 ) );
+    }
+
+    template <int VR = view_rank>
+    KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, linear_algebra_type>
+    operator()( const int i[2] ) const
+    {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
+        return linear_algebra_type( &_v( i[0], i[1], 0 ), _v.stride( 2 ) );
     }
 
     // Access the view data through full index arguments.
@@ -392,6 +444,8 @@ struct VectorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, value_type&>
     operator()( const int i0, const int i1, const int i2, const int i3 ) const
     {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, i2, i3 );
     }
 
@@ -399,6 +453,8 @@ struct VectorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, value_type&>
     operator()( const int i0, const int i1, const int i2 ) const
     {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, i2 );
     }
 };
@@ -451,6 +507,8 @@ struct TensorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, linear_algebra_type>
     operator()( const int i0, const int i1, const int i2 ) const
     {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return linear_algebra_type( &_v( i0, i1, i2, 0 ), dim1 * _v.stride( 3 ),
                                     _v.stride( 3 ) );
     }
@@ -459,7 +517,31 @@ struct TensorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, linear_algebra_type>
     operator()( const int i0, const int i1 ) const
     {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return linear_algebra_type( &_v( i0, i1, 0 ), dim1 * _v.stride( 2 ),
+                                    _v.stride( 2 ) );
+    }
+
+    // Access the view data as a tensor through array-based point-wise index
+    // arguments. The data layout is the same as above.
+    template <int VR = view_rank>
+    KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, linear_algebra_type>
+    operator()( const int i[3] ) const
+    {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
+        return linear_algebra_type( &_v( i[0], i[1], i[2], 0 ),
+                                    dim1 * _v.stride( 3 ), _v.stride( 3 ) );
+    }
+
+    template <int VR = view_rank>
+    KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, linear_algebra_type>
+    operator()( const int i[2] ) const
+    {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
+        return linear_algebra_type( &_v( i[0], i[1], 0 ), dim1 * _v.stride( 2 ),
                                     _v.stride( 2 ) );
     }
 
@@ -468,6 +550,8 @@ struct TensorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<4 == VR, value_type&>
     operator()( const int i0, const int i1, const int i2, const int i3 ) const
     {
+        static_assert( 4 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, i2, i3 );
     }
 
@@ -475,6 +559,8 @@ struct TensorViewWrapper
     KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<3 == VR, value_type&>
     operator()( const int i0, const int i1, const int i2 ) const
     {
+        static_assert( 3 == VR, "This template parameter is for SFINAE only "
+                                "and should not be given explicitly" );
         return _v( i0, i1, i2 );
     }
 };

--- a/unit_test/tstGridOperator2d.hpp
+++ b/unit_test/tstGridOperator2d.hpp
@@ -101,9 +101,11 @@ struct GridFunc
         // Set up the local dependency to be the identity.
         baz( i, j ) = { { 1.0, 0.0 }, { 0.0, 1.0 } };
 
-        // Assign foo_out - build a point-wise expression to do this.
+        // Assign foo_out - build a point-wise expression to do this. Test out
+        // both separate index and array-based indices.
+        const int index[2] = { i, j };
         auto baz_t_foo_in_t_2 =
-            baz( i, j ) * ( foo_in( i, j ) + foo_in( i, j ) );
+            baz( index ) * ( foo_in( index ) + foo_in( i, j ) );
         for ( int d = 0; d < 2; ++d )
             foo_out_access( i, j, d ) += baz_t_foo_in_t_2( d ) + i + j;
 

--- a/unit_test/tstGridOperator3d.hpp
+++ b/unit_test/tstGridOperator3d.hpp
@@ -143,9 +143,11 @@ struct GridFunc
         baz( i, j,
              k ) = { { 1.0, 0.0, 0.0 }, { 0.0, 1.0, 0.0 }, { 0.0, 0.0, 1.0 } };
 
-        // Assign foo_out - build a point-wise expression to do this.
+        // Assign foo_out - build a point-wise expression to do this. Test out
+        // both separate index and array-based indices.
+        const int index[3] = { i, j, k };
         auto baz_t_foo_in_t_2 =
-            baz( i, j, k ) * ( foo_in( i, j, k ) + foo_in( i, j, k ) );
+            baz( index ) * ( foo_in( index ) + foo_in( i, j, k ) );
         for ( int d = 0; d < 3; ++d )
             foo_out_access( i, j, k, d ) += baz_t_foo_in_t_2( d ) + i + j + k;
 


### PR DESCRIPTION
This PR adds array-based inputs for `operator()` in the view wrappers to allow for easier implementation of space dimension agnostic grid operator kernels.