### PR TITLE
Require hypre in Cabana

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: hypre/src
         run: |
           cmake -B build \
-            -DHYPRE_INSTALL_PREFIX=$HOME/hypre \
+            -DCMAKE_INSTALL_PREFIX=$HOME/hypre \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
@@ -91,7 +91,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=$HOME/cabana \
             -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/hypre" \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
-            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+            -DCabana_REQUIRE_HYPRE=ON
           cmake --build build --parallel 2
           cmake --install build
       - name: Cache boost
@@ -137,7 +138,7 @@ jobs:
           cmake -B build \
             -DCMAKE_INSTALL_PREFIX=$HOME/picasso \
             -DMPIEXEC_MAX_NUMPROCS=2 -DMPIEXEC_PREFLAGS="--oversubscribe" \
-            -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/arborx;$HOME/cabana;$HOME/boost;$HOME/silo;$HOME/hypre" \
+            -DCMAKE_PREFIX_PATH="$HOME/arborx;$HOME/cabana;$HOME/boost;$HOME/silo" \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CXX_FLAGS="-Wall -pedantic --coverage" \
             -DPicasso_ENABLE_TESTING=ON \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,8 +64,7 @@ jobs:
         uses: actions/checkout@v2.2.0
         with:
           repository: hypre-space/hypre
-          # FIXME: use tag when https://github.com/hypre-space/hypre/pull/423 is included in a release
-          ref: ae8bbf619ce243e9dab095a8e115717463d3db83
+          ref: v2.22.1
           path: hypre
       - name: Build hypre
         working-directory: hypre/src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,19 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
                  "${CMAKE_BINARY_DIR}/googletest-build")
 
-# find dependencies
+# find dependencies (MPI, Kokkos, and HYPRE found through Cabana)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package(CLANG_FORMAT 10)
-find_package(MPI REQUIRED)
-find_package(Kokkos REQUIRED)
 find_package(Cabana REQUIRED COMPONENTS Cabana::Cajita Cabana::cabanacore)
-find_package(HYPRE REQUIRED)
 find_package(ArborX REQUIRED)
 find_package(Boost 1.66.0 REQUIRED)
+
+if( NOT Cabana_ENABLE_CAJITA )
+  message( FATAL_ERROR "Cabana must be compiled with Cajita enabled" )
+endif()
+if( NOT Cabana_ENABLE_HYPRE )
+  message( FATAL_ERROR "Cabana must be compiled with HYPRE" )
+endif()
 
 # find dependencies (from Cabana CMakeLists.txt)
 macro(Picasso_add_dependency)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
 # find dependencies (MPI, Kokkos, and HYPRE found through Cabana)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package(CLANG_FORMAT 10)
-find_package(Cabana REQUIRED COMPONENTS Cabana::Cajita Cabana::cabanacore)
+find_package(Cabana REQUIRED 0.4 COMPONENTS Cabana::Cajita Cabana::cabanacore)
 find_package(ArborX REQUIRED)
 find_package(Boost 1.66.0 REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,8 +39,6 @@ set(SOURCES
 add_library(picasso ${SOURCES})
 
 target_link_libraries(picasso
-  Kokkos::kokkos
-  MPI::MPI_CXX
   Cabana::cabanacore
   Cabana::Cajita
   ArborX::ArborX


### PR DESCRIPTION
Should fix hypre build issues and give more clear errors. 

Only explicitly finds packages and links libraries that are not available through Cabana+Cajita