### PR TITLE
Change name of Tensor field type to Matrix

### DIFF
--- a/unit_test/tstGridOperator2d.hpp
+++ b/unit_test/tstGridOperator2d.hpp
@@ -63,7 +63,7 @@ struct BarOut : Field::Scalar<double>
     static std::string label() { return "bar_out"; }
 };
 
-struct Baz : Field::Tensor<double, 2, 2>
+struct Baz : Field::Matrix<double, 2, 2>
 {
     static std::string label() { return "baz"; }
 };

--- a/unit_test/tstGridOperator3d.hpp
+++ b/unit_test/tstGridOperator3d.hpp
@@ -62,7 +62,7 @@ struct BarOut : Field::Scalar<double>
     static std::string label() { return "bar_out"; }
 };
 
-struct Baz : Field::Tensor<double, 3, 3>
+struct Baz : Field::Matrix<double, 3, 3>
 {
     static std::string label() { return "baz"; }
 };

--- a/unit_test/tstParticleInterpolation.hpp
+++ b/unit_test/tstParticleInterpolation.hpp
@@ -42,7 +42,7 @@ struct ParticleVector : Field::Vector<double, 3>
     static std::string label() { return "particle_vector"; }
 };
 
-struct ParticleTensor : Field::Tensor<double, 3, 3>
+struct ParticleTensor : Field::Matrix<double, 3, 3>
 {
     static std::string label() { return "particle_tensor"; }
 };

--- a/unit_test/tstParticleList.hpp
+++ b/unit_test/tstParticleList.hpp
@@ -31,7 +31,7 @@ struct Foo : Field::Scalar<double>
     static std::string label() { return "foo"; }
 };
 
-struct Bar : Field::Tensor<double, 3, 3>
+struct Bar : Field::Matrix<double, 3, 3>
 {
     static std::string label() { return "bar"; }
 };


### PR DESCRIPTION
This PR changes the Picasso `Tensor` field type to `Matrix`, in order to better match semantics with the `Matrix` type in `BachedLinearAlgebra`.