### PR TITLE
Update unit tests for silo particle writer label change. Added label to ParticleList.

### DIFF
--- a/src/Picasso_ParticleList.hpp
+++ b/src/Picasso_ParticleList.hpp
@@ -246,6 +246,7 @@ class ParticleList
     ParticleList( const std::string& label, const std::shared_ptr<Mesh>& mesh )
         : _aosoa( label )
         , _mesh( mesh )
+        , _label( label )
     {
     }
 
@@ -258,6 +259,9 @@ class ParticleList
 
     // Get the mesh.
     const Mesh& mesh() { return *_mesh; }
+
+    // Get the label
+    const std::string& label() { return _label; }
 
     // Get a slice of a given field.
     template <class FieldTag>
@@ -281,6 +285,7 @@ class ParticleList
   private:
     aosoa_type _aosoa;
     std::shared_ptr<Mesh> _mesh;
+    std::string _label;
 };
 
 //---------------------------------------------------------------------------//

--- a/unit_test/tstFacetGeometry.hpp
+++ b/unit_test/tstFacetGeometry.hpp
@@ -524,7 +524,7 @@ void initExample()
 
 #ifdef Cabana_ENABLE_SILO
     Cajita::Experimental::SiloParticleOutput::writeTimeStep(
-        mesh->localGrid()->globalGrid(), 0, 0.0,
+        "particles", mesh->localGrid()->globalGrid(), 0, 0.0,
         particles.slice( Field::PhysicalPosition<3>() ),
         particles.slice( Field::VolumeId() ) );
 #endif

--- a/unit_test/tstParticleLevelSet.hpp
+++ b/unit_test/tstParticleLevelSet.hpp
@@ -91,7 +91,7 @@ void zalesaksTest( const std::string& filename )
     double time = 0.0;
 #ifdef Cabana_ENABLE_SILO
     Cajita::Experimental::SiloParticleOutput::writeTimeStep(
-        mesh->localGrid()->globalGrid(), 0, time,
+        "particles", mesh->localGrid()->globalGrid(), 0, time,
         particles->slice( Field::PhysicalPosition<3>() ),
         particles->slice( Field::Color() ),
         particles->slice( Field::CommRank() ) );
@@ -171,7 +171,7 @@ void zalesaksTest( const std::string& filename )
         time += 1.0;
 #ifdef Cabana_ENABLE_SILO
         Cajita::Experimental::SiloParticleOutput::writeTimeStep(
-            mesh->localGrid()->globalGrid(), t + 1, time,
+            "particles", mesh->localGrid()->globalGrid(), t + 1, time,
             particles->slice( Field::PhysicalPosition<3>() ),
             particles->slice( Field::Color() ),
             particles->slice( Field::CommRank() ) );


### PR DESCRIPTION
This MR adds labels to `ParticleList` and changes two unit tests to use the updated Silo particle writer method accepting a string label.