### PR TITLE
Add surface particles intialization to ParticleInit.

### DIFF
--- a/src/Picasso_ParticleInit.hpp
+++ b/src/Picasso_ParticleInit.hpp
@@ -432,8 +432,7 @@ void initializeParticlesSurface( InitRandom, const ExecutionSpace& exec_space,
     // Get the particles.
     auto& particles = surface_particle_list.aosoa();
 
-    // Allocate enough space for the case the particles consume the entire
-    // local grid.
+    // Allocate the particles.
     int num_facets = surface.facets.extent( 0 );
     int num_particles = particles_per_facet * num_facets;
     particles.resize( num_particles );
@@ -446,7 +445,7 @@ void initializeParticlesSurface( InitRandom, const ExecutionSpace& exec_space,
     rnd_type pool;
     pool.init( seed, num_facets );
 
-    // Fixme: Re-thread over particles instead of facets.
+    // FIXME: Re-thread over particles instead of facets.
     // Initialize particles.
     Kokkos::parallel_for(
         "Picasso::ParticleInit::RandomSurface",

--- a/src/Picasso_ParticleList.hpp
+++ b/src/Picasso_ParticleList.hpp
@@ -262,6 +262,7 @@ class ParticleList
 
     // Get the label
     const std::string& label() { return _label; }
+    const std::string& label() const { return _label; }
 
     // Get a slice of a given field.
     template <class FieldTag>


### PR DESCRIPTION
This PR adds a method to generate particles on a faceted surface (e.g. one produced by marching cubes). Currently only random initialization.