### PR TITLE
Arbitrary field (scalar/vector) APIC  p2g/g2p

### DIFF
--- a/src/Picasso_APIC.hpp
+++ b/src/Picasso_APIC.hpp
@@ -52,12 +52,13 @@ typename SplineDataType::scalar_type KOKKOS_INLINE_FUNCTION inertialScaling(
 // Interpolate particle momentum and mass to a collocated momentum
 // grid. (Second and Third order splines). Requires SplineValue,
 // SplineDistance, and SplinePhysicalCellSize when constructing the spline
-// data.
+// data. ParticleField matrix c_p (4*N matrix) is composed of particle field u_p
+// (1*N matrix) and particle  affine matrix B_p ( 3*N matrix ).
 template <class ParticleMass, class ParticleField, class SplineDataType,
-          class GridField, class GridMass>
+          class GridMass, class GridField>
 KOKKOS_INLINE_FUNCTION void
-p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
-     const GridMass& m_i, const SplineDataType& sd,
+p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridMass& m_i,
+     const GridField& mu_i, const SplineDataType& sd,
      typename std::enable_if<
          ( ( Cajita::isNode<typename SplineDataType::entity_type>::value ||
              Cajita::isCell<typename SplineDataType::entity_type>::value ) &&
@@ -83,7 +84,9 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 
     using value_type = typename GridField::original_value_type;
 
-    static_assert( 4 == ParticleField::extent_0, "APIC 4 modes" );
+    static_assert( 4 == ParticleField::extent_0,
+                   "APIC requires a 4xN matrix, where N matches the dimension "
+                   "of the input field" );
 
     // Number of field components.
     static constexpr int ncomp = ParticleField::extent_1;
@@ -92,7 +95,7 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
     LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
     for ( int d = 0; d < ncomp; ++d )
     {
-        // transpose of c_p is already taken accounted in B_p
+        // B_p is sliced from c_p and is transposed.
         B_p( d, 0 ) = c_p( 1, d );
         B_p( d, 1 ) = c_p( 2, d );
         B_p( d, 2 ) = c_p( 3, d );
@@ -141,12 +144,13 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 // Interpolate particle momentum and mass to a staggered momentum
 // grid. (Second and Third order splines). Requires SplineValue,
 // SplineDistance, and SplinePhysicalCellSize when constructing the spline
-// data.
+// data.ParticleField matrix c_p (4*N matrix) is composed of particle field u_p
+// (1*N matrix) and particle  affine matrix B_p ( 3*N matrix ).
 template <class ParticleMass, class ParticleField, class SplineDataType,
-          class GridField, class GridMass>
+          class GridMass, class GridField>
 KOKKOS_INLINE_FUNCTION void
-p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
-     const GridMass& m_i, const SplineDataType& sd,
+p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridMass& m_i,
+     const GridField& mu_i, const SplineDataType& sd,
      typename std::enable_if<
          ( ( Cajita::isEdge<typename SplineDataType::entity_type>::value ||
              Cajita::isFace<typename SplineDataType::entity_type>::value ) &&
@@ -172,7 +176,9 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 
     using value_type = typename GridField::original_value_type;
 
-    static_assert( 4 == ParticleField::extent_0, "APIC 4 modes" );
+    static_assert( 4 == ParticleField::extent_0,
+                   "APIC requires a 4xN matrix, where N matches the dimension "
+                   "of the input field" );
 
     static_assert( 3 == ParticleField::extent_1,
                    "APIC requires 3 space dimensions" );
@@ -184,7 +190,7 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
     LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
     for ( int d = 0; d < ncomp; ++d )
     {
-        // transpose of c_p is already taken accounted in B_p
+        // B_p is sliced from c_p and is transposed.
         B_p( d, 0 ) = c_p( 1, d );
         B_p( d, 1 ) = c_p( 2, d );
         B_p( d, 2 ) = c_p( 3, d );
@@ -228,12 +234,14 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 //---------------------------------------------------------------------------//
 // Interpolate particle momentum and mass to a collocated momentum
 // grid. (First order splines). Requires SplineValue and SplineGradient when
-// constructing the spline data.
+// constructing the spline data. ParticleField matrix c_p (4*N matrix) is
+// composed of particle field u_p (1*N matrix) and particle  affine matrix B_p (
+// 3*N matrix ).
 template <class ParticleMass, class ParticleField, class SplineDataType,
-          class GridField, class GridMass>
+          class GridMass, class GridField>
 KOKKOS_INLINE_FUNCTION void
-p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
-     const GridMass& m_i, const SplineDataType& sd,
+p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridMass& m_i,
+     const GridField& mu_i, const SplineDataType& sd,
      typename std::enable_if<
          ( ( Cajita::isNode<typename SplineDataType::entity_type>::value ||
              Cajita::isCell<typename SplineDataType::entity_type>::value ) &&
@@ -256,7 +264,9 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 
     using value_type = typename GridField::original_value_type;
 
-    static_assert( 4 == ParticleField::extent_0, "APIC 4 modes" );
+    static_assert( 4 == ParticleField::extent_0,
+                   "APIC requires a 4xN matrix, where N matches the dimension "
+                   "of the input field" );
 
     // Number of field components.
     static constexpr int ncomp = ParticleField::extent_1;
@@ -265,7 +275,7 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
     LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
     for ( int d = 0; d < ncomp; ++d )
     {
-        // transpose of c_p is already taken accounted in B_p
+        // B_p is sliced from c_p and is transposed.
         B_p( d, 0 ) = c_p( 1, d );
         B_p( d, 1 ) = c_p( 2, d );
         B_p( d, 2 ) = c_p( 3, d );
@@ -310,12 +320,14 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 //---------------------------------------------------------------------------//
 // Interpolate particle momentum and mass to a staggered momentum grid. (First
 // order splines). Requires SplineValue and SplineGradient when constructing
-// the spline data.
+// the spline data. ParticleField matrix c_p (4*N matrix) is composed of
+// particle field u_p (1*N matrix) and particle  affine matrix B_p ( 3*N matrix
+// ).
 template <class ParticleMass, class ParticleField, class SplineDataType,
-          class GridField, class GridMass>
+          class GridMass, class GridField>
 KOKKOS_INLINE_FUNCTION void
-p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
-     const GridMass& m_i, const SplineDataType& sd,
+p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridMass& m_i,
+     const GridField& mu_i, const SplineDataType& sd,
      typename std::enable_if<
          ( ( Cajita::isEdge<typename SplineDataType::entity_type>::value ||
              Cajita::isFace<typename SplineDataType::entity_type>::value ) &&
@@ -338,7 +350,9 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 
     using value_type = typename GridField::original_value_type;
 
-    static_assert( 4 == ParticleField::extent_0, "APIC 4 modes" );
+    static_assert( 4 == ParticleField::extent_0,
+                   "APIC requires a 4xN matrix, where N matches the dimension "
+                   "of the input field" );
 
     static_assert( 3 == ParticleField::extent_1,
                    "APIC requires 3 space dimensions" );
@@ -350,7 +364,7 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
     LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
     for ( int d = 0; d < ncomp; ++d )
     {
-        // transpose of c_p is already taken accounted in B_p
+        // B_p is sliced from c_p and is transposed.
         B_p( d, 0 ) = c_p( 1, d );
         B_p( d, 1 ) = c_p( 2, d );
         B_p( d, 2 ) = c_p( 3, d );
@@ -389,17 +403,17 @@ p2g( const ParticleMass& m_p, const ParticleField& c_p, const GridField& mu_i,
 }
 
 //---------------------------------------------------------------------------//
-// Interpolate collocated grid velocity to the particle. Requires SplineValue
+// Interpolate collocated grid field to the particle. Requires SplineValue
 // and SplineDistance when constructing the spline data.
-template <class GridVelocity, class SplineDataType, class ParticleField>
+template <class GridField, class SplineDataType, class ParticleField>
 KOKKOS_INLINE_FUNCTION void
-g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
+g2p( const GridField& u_i, ParticleField& c_p, const SplineDataType& sd,
      typename std::enable_if<
          ( Cajita::isNode<typename SplineDataType::entity_type>::value ||
            Cajita::isCell<typename SplineDataType::entity_type>::value ),
          void*>::type = 0 )
 {
-    using value_type = typename GridVelocity::value_type;
+    using value_type = typename GridField::value_type;
 
     static_assert( SplineDataType::has_weight_values,
                    "APIC::g2p requires spline weight values" );
@@ -430,12 +444,13 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
                 // Projection weight.
                 w_ip = sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
 
-                // Entity velocity
+                // Entity field
                 auto u_e =
                     u_i( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k] );
 
-                // Update velocity.
-                u_p += w_ip * u_e;
+                // Update field.
+                // FIXME: += operator does not work for scalar field
+                u_p = u_p + w_ip * u_e;
 
                 // Physical distance to entity.
                 distance( Dim::I ) = sd.d[Dim::I][i];
@@ -449,7 +464,7 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
     // update ParticleField
     for ( int d = 0; d < ncomp; ++d )
     {
-        // transpose of c_p is already taken accounted in B_p
+        // c_p is reconstructed from particle velocity and B_p^{T}
         c_p( 0, d ) = u_p( d );
         c_p( 1, d ) = B_p( d, 0 );
         c_p( 2, d ) = B_p( d, 1 );
@@ -458,11 +473,11 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
 }
 
 //---------------------------------------------------------------------------//
-// Interpolate staggered grid velocity to the particle. Requires SplineValue
+// Interpolate staggered grid field to the particle. Requires SplineValue
 // and SplineDistance when constructing the spline data.
-template <class GridVelocity, class SplineDataType, class ParticleField>
+template <class GridField, class SplineDataType, class ParticleField>
 KOKKOS_INLINE_FUNCTION void
-g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
+g2p( const GridField& u_i, ParticleField& c_p, const SplineDataType& sd,
      typename std::enable_if<
          ( Cajita::isEdge<typename SplineDataType::entity_type>::value ||
            Cajita::isFace<typename SplineDataType::entity_type>::value ),
@@ -474,7 +489,7 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
     static_assert( SplineDataType::has_physical_distance,
                    "APIC::g2p requires spline distance" );
 
-    using value_type = typename GridVelocity::value_type;
+    using value_type = typename GridField::value_type;
 
     static_assert( 4 == ParticleField::extent_0, "APIC 4 modes" );
 
@@ -488,7 +503,7 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
     LinearAlgebra::Vector<value_type, ncomp> u_p;
     LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
 
-    // Get the velocity dimension we are working on.
+    // Get the field dimension we are working on.
     const int dim = SplineDataType::entity_type::dim;
 
     // Reset the particle values.
@@ -505,7 +520,7 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
                 // Projection weight.
                 w_ip = sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
 
-                // Update velocity.
+                // Update field.
                 u_p( dim ) += w_ip * u_i( sd.s[Dim::I][i], sd.s[Dim::J][j],
                                           sd.s[Dim::K][k] );
 
@@ -524,7 +539,7 @@ g2p( const GridVelocity& u_i, ParticleField& c_p, const SplineDataType& sd,
     // update ParticleField
     for ( int d = 0; d < ncomp; ++d )
     {
-        // transpose of c_p is already taken accounted in B_p
+        // c_p is reconstructed from particle velocity and B_p^{T}
         c_p( 0, d ) = u_p( d );
         c_p( 1, d ) = B_p( d, 0 );
         c_p( 2, d ) = B_p( d, 1 );

--- a/src/Picasso_APIC.hpp
+++ b/src/Picasso_APIC.hpp
@@ -357,12 +357,9 @@ p2g( const ParticleMass& m_p, const ParticleVelocity& c_p, const GridMass& m_i,
     static_assert( 3 == ParticleVelocity::extent_1,
                    "APIC requires 3 space dimensions" );
 
-    // Number of field components.
-    constexpr int ncomp = ParticleVelocity::extent_1;
-
     // Affine Matrix
-    LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
-    for ( int d = 0; d < ncomp; ++d )
+    LinearAlgebra::Matrix<value_type, 3, 3> B_p;
+    for ( int d = 0; d < 3; ++d )
     {
         // B_p is sliced from c_p and is transposed.
         B_p( d, 0 ) = c_p( 1, d );
@@ -473,7 +470,7 @@ g2p( const GridField& u_i, ParticleField& c_p, const SplineDataType& sd,
 }
 
 //---------------------------------------------------------------------------//
-// Interpolate staggered grid field to the particle. Requires SplineValue
+// Interpolate staggered grid velocity to the particle. Requires SplineValue
 // and SplineDistance when constructing the spline data.
 template <class GridMomentum, class SplineDataType, class ParticleVelocity>
 KOKKOS_INLINE_FUNCTION void
@@ -496,12 +493,9 @@ g2p( const GridMomentum& u_i, ParticleVelocity& c_p, const SplineDataType& sd,
     static_assert( 3 == ParticleVelocity::extent_1,
                    "APIC requires 3 space dimensions" );
 
-    // Number of field components.
-    constexpr int ncomp = ParticleVelocity::extent_1;
-
     // Affine Matrix
-    LinearAlgebra::Vector<value_type, ncomp> u_p;
-    LinearAlgebra::Matrix<value_type, ncomp, 3> B_p;
+    LinearAlgebra::Vector<value_type, 3> u_p;
+    LinearAlgebra::Matrix<value_type, 3, 3> B_p;
 
     // Get the field dimension we are working on.
     const int dim = SplineDataType::entity_type::dim;
@@ -537,7 +531,7 @@ g2p( const GridMomentum& u_i, ParticleVelocity& c_p, const SplineDataType& sd,
             }
 
     // update ParticleVelocity
-    for ( int d = 0; d < ncomp; ++d )
+    for ( int d = 0; d < 3; ++d )
     {
         // c_p is reconstructed from particle velocity and B_p^{T}
         c_p( 0, d ) = u_p( d );

--- a/unit_test/tstAPIC.hpp
+++ b/unit_test/tstAPIC.hpp
@@ -77,9 +77,8 @@ void checkGridVelocity( std::integral_constant<int, 1>, const int cx,
 
 //---------------------------------------------------------------------------//
 // Check particle velocity and affine velocity. Computed in Mathematica.
-template <class ParticleVelocity, class AffineVelocity>
+template <class AffineVelocity>
 void checkParticleVelocity( std::integral_constant<int, 1>,
-                            const ParticleVelocity& pu_host,
                             const AffineVelocity& pb_host,
                             const double near_eps, const int array_dim )
 {
@@ -91,13 +90,13 @@ void checkParticleVelocity( std::integral_constant<int, 1>,
         { -3.2687262820030547, -4.911593173052676, 0.1993230728031179 },
         { -3.257811639242931, -4.91263564023696, 0.1993230728031392 } };
 
-    EXPECT_NEAR( pu_host( array_dim ), mathematica_u[array_dim], near_eps );
+    EXPECT_NEAR( pb_host( 0, array_dim ), mathematica_u[array_dim], near_eps );
 
-    EXPECT_NEAR( pb_host( array_dim, 0 ), mathematica_b[array_dim][0],
+    EXPECT_NEAR( pb_host( 1, array_dim ), mathematica_b[array_dim][0],
                  near_eps );
-    EXPECT_NEAR( pb_host( array_dim, 1 ), mathematica_b[array_dim][1],
+    EXPECT_NEAR( pb_host( 2, array_dim ), mathematica_b[array_dim][1],
                  near_eps );
-    EXPECT_NEAR( pb_host( array_dim, 2 ), mathematica_b[array_dim][2],
+    EXPECT_NEAR( pb_host( 3, array_dim ), mathematica_b[array_dim][2],
                  near_eps );
 }
 
@@ -195,9 +194,8 @@ void checkGridVelocity( std::integral_constant<int, 2>, const int cx,
 
 //---------------------------------------------------------------------------//
 // Check particle velocity and affine velocity. Computed in Mathematica.
-template <class ParticleVelocity, class AffineVelocity>
+template <class AffineVelocity>
 void checkParticleVelocity( std::integral_constant<int, 2>,
-                            const ParticleVelocity& pu_host,
                             const AffineVelocity& pb_host,
                             const double near_eps, const int array_dim )
 {
@@ -209,13 +207,13 @@ void checkParticleVelocity( std::integral_constant<int, 2>,
         { -3.388082785485041, -4.8514415741128385, 0.22254272203841385 },
         { -3.3766230251516975, -4.852482973202919, 0.22254272203843906 } };
 
-    EXPECT_NEAR( pu_host( array_dim ), mathematica_u[array_dim], near_eps );
+    EXPECT_NEAR( pb_host( 0, array_dim ), mathematica_u[array_dim], near_eps );
 
-    EXPECT_NEAR( pb_host( array_dim, 0 ), mathematica_b[array_dim][0],
+    EXPECT_NEAR( pb_host( 1, array_dim ), mathematica_b[array_dim][0],
                  near_eps );
-    EXPECT_NEAR( pb_host( array_dim, 1 ), mathematica_b[array_dim][1],
+    EXPECT_NEAR( pb_host( 2, array_dim ), mathematica_b[array_dim][1],
                  near_eps );
-    EXPECT_NEAR( pb_host( array_dim, 2 ), mathematica_b[array_dim][2],
+    EXPECT_NEAR( pb_host( 3, array_dim ), mathematica_b[array_dim][2],
                  near_eps );
 }
 
@@ -375,9 +373,8 @@ void checkGridVelocity( std::integral_constant<int, 3>, const int cx,
 
 //---------------------------------------------------------------------------//
 // Check particle velocity and affine velocity. Computed in Mathematica.
-template <class ParticleVelocity, class AffineVelocity>
+template <class AffineVelocity>
 void checkParticleVelocity( std::integral_constant<int, 3>,
-                            const ParticleVelocity& pu_host,
                             const AffineVelocity& pb_host,
                             const double near_eps, const int array_dim )
 {
@@ -389,13 +386,13 @@ void checkParticleVelocity( std::integral_constant<int, 3>,
         { -4.634471032846672, -6.635011231192498, 0.3047536994385796 },
         { -4.618961679400126, -6.636420491918657, 0.304753699438543 } };
 
-    EXPECT_NEAR( pu_host( array_dim ), mathematica_u[array_dim], near_eps );
+    EXPECT_NEAR( pb_host( 0, array_dim ), mathematica_u[array_dim], near_eps );
 
-    EXPECT_NEAR( pb_host( array_dim, 0 ), mathematica_b[array_dim][0],
+    EXPECT_NEAR( pb_host( 1, array_dim ), mathematica_b[array_dim][0],
                  near_eps );
-    EXPECT_NEAR( pb_host( array_dim, 1 ), mathematica_b[array_dim][1],
+    EXPECT_NEAR( pb_host( 2, array_dim ), mathematica_b[array_dim][1],
                  near_eps );
-    EXPECT_NEAR( pb_host( array_dim, 2 ), mathematica_b[array_dim][2],
+    EXPECT_NEAR( pb_host( 3, array_dim ), mathematica_b[array_dim][2],
                  near_eps );
 }
 
@@ -571,8 +568,7 @@ void collocatedTest()
     int cz = 95;
 
     // Particle velocity.
-    Kokkos::View<double[3], TEST_MEMSPACE> pu( "pu" );
-    Kokkos::View<double[3][3], TEST_MEMSPACE> pb( "pb" );
+    Kokkos::View<double[4][3], TEST_MEMSPACE> pb( "pb" );
 
     // Create a grid vector on the entities.
     auto grid_vector = createArray( mesh, Location(), Foo() );
@@ -613,30 +609,27 @@ void collocatedTest()
                 createSpline( Location(), InterpolationOrder<Order>(),
                               local_mesh, x, SplineValue(), SplineDistance() );
 
-            LinearAlgebra::Vector<double, 3> vel;
-            LinearAlgebra::Matrix<double, 3, 3> aff;
+            LinearAlgebra::Matrix<double, 4, 3> aff;
 
-            APIC::g2p( gv_wrapper, vel, aff, sd );
+            APIC::g2p( gv_wrapper, aff, sd );
 
             for ( int d = 0; d < 3; ++d )
-                pu( d ) = vel( d );
+                pb( 0, d ) = aff( 0, d );
 
             for ( int i = 0; i < 3; ++i )
                 for ( int j = 0; j < 3; ++j )
-                    pb( i, j ) = aff( i, j );
+                    pb( i + 1, j ) = aff( i + 1, j );
         } );
 
     // Check particle velocity. Computed in Mathematica.
-    auto pu_host =
-        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), pu );
     auto pb_host =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), pb );
-    checkParticleVelocity( std::integral_constant<int, Order>(), pu_host,
-                           pb_host, near_eps, 0 );
-    checkParticleVelocity( std::integral_constant<int, Order>(), pu_host,
-                           pb_host, near_eps, 1 );
-    checkParticleVelocity( std::integral_constant<int, Order>(), pu_host,
-                           pb_host, near_eps, 2 );
+    checkParticleVelocity( std::integral_constant<int, Order>(), pb_host,
+                           near_eps, 0 );
+    checkParticleVelocity( std::integral_constant<int, Order>(), pb_host,
+                           near_eps, 1 );
+    checkParticleVelocity( std::integral_constant<int, Order>(), pb_host,
+                           near_eps, 2 );
 
     // Reset the grid view.
     Kokkos::deep_copy( gv_view, 0.0 );
@@ -658,17 +651,16 @@ void collocatedTest()
                               local_mesh, x, SplineValue(), SplineGradient(),
                               SplineDistance(), SplineCellSize() );
 
-            LinearAlgebra::Vector<double, 3> vel;
-            LinearAlgebra::Matrix<double, 3, 3> aff;
+            LinearAlgebra::Matrix<double, 4, 3> aff;
 
             for ( int d = 0; d < 3; ++d )
-                vel( d ) = pu( d );
+                aff( 0, d ) = pb( 0, d );
 
             for ( int i = 0; i < 3; ++i )
                 for ( int j = 0; j < 3; ++j )
-                    aff( i, j ) = pb( i, j );
+                    aff( i + 1, j ) = pb( i + 1, j );
 
-            APIC::p2g( pm, vel, aff, gv_sv, gm_sv, sd );
+            APIC::p2g( pm, aff, gv_sv, gm_sv, sd );
         } );
     Kokkos::Experimental::contribute( gv_view, gv_sv );
     Kokkos::Experimental::contribute( gm_view, gm_sv );
@@ -748,8 +740,7 @@ void staggeredTest()
     int cz = 95;
 
     // Particle velocity.
-    Kokkos::View<double[3], TEST_MEMSPACE> pu( "pu" );
-    Kokkos::View<double[3][3], TEST_MEMSPACE> pb( "pb" );
+    Kokkos::View<double[4][3], TEST_MEMSPACE> pb( "pb" );
 
     // Create a grid scalar on the faces in the test dimension.
     auto grid_scalar = createArray( mesh, FieldLocation::Face<Dim>(), Bar() );
@@ -786,26 +777,23 @@ void staggeredTest()
                                     InterpolationOrder<Order>(), local_mesh, x,
                                     SplineValue(), SplineDistance() );
 
-            LinearAlgebra::Vector<double, 3> vel;
-            LinearAlgebra::Matrix<double, 3, 3> aff;
+            LinearAlgebra::Matrix<double, 4, 3> aff;
 
-            APIC::g2p( gs_wrapper, vel, aff, sd );
+            APIC::g2p( gs_wrapper, aff, sd );
 
             for ( int d = 0; d < 3; ++d )
-                pu( d ) = vel( d );
+                pb( 0, d ) = aff( 0, d );
 
             for ( int i = 0; i < 3; ++i )
                 for ( int j = 0; j < 3; ++j )
-                    pb( i, j ) = aff( i, j );
+                    pb( i + 1, j ) = aff( i + 1, j );
         } );
 
     // Check particle velocity. Computed in Mathematica.
-    auto pu_host =
-        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), pu );
     auto pb_host =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), pb );
-    checkParticleVelocity( std::integral_constant<int, Order>(), pu_host,
-                           pb_host, near_eps, Dim );
+    checkParticleVelocity( std::integral_constant<int, Order>(), pb_host,
+                           near_eps, Dim );
 
     // Reset the grid view.
     Kokkos::deep_copy( gs_view, 0.0 );
@@ -827,17 +815,16 @@ void staggeredTest()
                                     SplineValue(), SplineGradient(),
                                     SplineDistance(), SplineCellSize() );
 
-            LinearAlgebra::Vector<double, 3> vel;
-            LinearAlgebra::Matrix<double, 3, 3> aff;
+            LinearAlgebra::Matrix<double, 4, 3> aff;
 
             for ( int d = 0; d < 3; ++d )
-                vel( d ) = pu( d );
+                aff( 0, d ) = pb( 0, d );
 
             for ( int i = 0; i < 3; ++i )
                 for ( int j = 0; j < 3; ++j )
-                    aff( i, j ) = pb( i, j );
+                    aff( i + 1, j ) = pb( i + 1, j );
 
-            APIC::p2g( pm, vel, aff, gs_sv, gm_sv, sd );
+            APIC::p2g( pm, aff, gs_sv, gm_sv, sd );
         } );
     Kokkos::Experimental::contribute( gs_view, gs_sv );
     Kokkos::Experimental::contribute( gm_view, gm_sv );

--- a/unit_test/tstAPIC.hpp
+++ b/unit_test/tstAPIC.hpp
@@ -660,7 +660,7 @@ void collocatedTest()
                 for ( int j = 0; j < 3; ++j )
                     aff( i + 1, j ) = pb( i + 1, j );
 
-            APIC::p2g( pm, aff, gv_sv, gm_sv, sd );
+            APIC::p2g( pm, aff, gm_sv, gv_sv, sd );
         } );
     Kokkos::Experimental::contribute( gv_view, gv_sv );
     Kokkos::Experimental::contribute( gm_view, gm_sv );
@@ -824,7 +824,7 @@ void staggeredTest()
                 for ( int j = 0; j < 3; ++j )
                     aff( i + 1, j ) = pb( i + 1, j );
 
-            APIC::p2g( pm, aff, gs_sv, gm_sv, sd );
+            APIC::p2g( pm, aff, gm_sv, gs_sv, sd );
         } );
     Kokkos::Experimental::contribute( gs_view, gs_sv );
     Kokkos::Experimental::contribute( gm_view, gm_sv );


### PR DESCRIPTION
modify APIC to have scalar/vector p2g/g2p interpolation with single ParticleField. ParticleField c_p is composed of

for vector field
c_p[4,3] matrix = u_p[1, 3] matrix  + B_p[3, 3] matrix ( combined by row )

for scalar field
c_p[4,1] matrix = u_p[1, 1] matrix   + B_p[3, 1] matrix ( combined by row )