### PR TITLE
Use tagged dependencies for CI and develop/master for nightly

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -1,11 +1,10 @@
-name: CI
+name: Nightly
 on:
   push:
     branches:
-      - master
-  pull_request:
-    branches:
-      - master
+      - nightly_testing
+  schedule:
+    - cron:  '0 3 * * *'
 
 jobs:
   CI:
@@ -15,31 +14,16 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu:latest']
-        cxx: ['g++', 'clang++']
         openmp: ['ON', 'OFF']
-        cmake_build_type: ['Debug', 'Release']
-        kokkos_ver: ['3.4.01']
-        coverage: ['OFF']
-        include:
-          - distro: 'ubuntu:latest'
-            cxx: 'g++'
-            openmp: 'ON'
-            cmake_build_type: 'Debug'
-            kokkos_ver: '3.4.01'
-            coverage: 'ON'
+        cmake_build_type: ['Debug']
     runs-on: ubuntu-20.04
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:
-      - name: Get trail license
-        if: ${{ matrix.cxx == 'icpc' }}
-        run: |
-          mkdir ~/Licenses
-          curl https://dynamicinstaller.intel.com/api/v2/license > ~/Licenses/intel.lic
       - name: Checkout kokkos
         uses: actions/checkout@v2.2.0
         with:
           repository: kokkos/kokkos
-          ref: ${{ matrix.kokkos_ver }}
+          ref: develop
           path: kokkos
       - name: Build kokkos
         working-directory: kokkos
@@ -47,7 +31,6 @@ jobs:
           cmake -B build \
             -DCMAKE_INSTALL_PREFIX=$HOME/kokkos \
             -DKokkos_ENABLE_OPENMP=${{ matrix.openmp }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DKokkos_ENABLE_HWLOC=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
           cmake --build build --parallel 2
@@ -56,7 +39,7 @@ jobs:
         uses: actions/checkout@v2.2.0
         with:
           repository: arborx/ArborX
-          ref: v1.2
+          ref: master
           path: arborx
       - name: Build arborx
         working-directory: arborx
@@ -64,7 +47,6 @@ jobs:
           cmake -B build \
             -DCMAKE_PREFIX_PATH=${HOME}/kokkos \
             -DCMAKE_INSTALL_PREFIX=$HOME/arborx \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
           cmake --build build --parallel 2
           cmake --install build
@@ -72,7 +54,7 @@ jobs:
         uses: actions/checkout@v2.2.0
         with:
           repository: ECP-CoPA/Cabana
-          ref: 0.5.0
+          ref: master
           path: cabana
       - name: Build Cabana
         working-directory: cabana
@@ -80,7 +62,6 @@ jobs:
           cmake -B build \
             -DCMAKE_INSTALL_PREFIX=$HOME/cabana \
             -DCMAKE_PREFIX_PATH="$HOME/kokkos" \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
           cmake --build build --parallel 2
           cmake --install build
@@ -111,15 +92,10 @@ jobs:
         uses: actions/checkout@v2.2.0
       - name: Build Picasso
         run: |
-          if [[ ${{ matrix.coverage }} == 'ON' ]]; then
-            cmake_cxx_flags+=( "--coverage -O0" )
-            cmake_opts+=( "-DCMAKE_EXE_LINKER_FLAGS=--coverage -DCMAKE_SHARED_LINKER_FLAGS=--coverage" )
-          fi
           cmake -B build \
             -DCMAKE_INSTALL_PREFIX=$HOME/picasso \
             -DMPIEXEC_MAX_NUMPROCS=2 -DMPIEXEC_PREFLAGS="--oversubscribe" \
             -DCMAKE_PREFIX_PATH="$HOME/arborx;$HOME/cabana;$HOME/boost" \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CXX_FLAGS="-Wall -pedantic ${cmake_cxx_flags}" \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DPicasso_ENABLE_TESTING=ON \


### PR DESCRIPTION
Ensures CI failures are useful for PRs