### PR TITLE
Require Kokkos 3.7 and use Kokkos math functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,14 +18,14 @@ jobs:
         cxx: ['g++', 'clang++']
         openmp: ['ON', 'OFF']
         cmake_build_type: ['Debug', 'Release']
-        kokkos_ver: ['3.4.01']
+        kokkos_ver: ['3.7.01']
         coverage: ['OFF']
         include:
           - distro: 'ubuntu:latest'
             cxx: 'g++'
             openmp: 'ON'
             cmake_build_type: 'Debug'
-            kokkos_ver: '3.4.01'
+            kokkos_ver: '3.7.01'
             coverage: 'ON'
     runs-on: ubuntu-20.04
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ find_package(Cabana REQUIRED 0.5 COMPONENTS Cabana::Cajita Cabana::cabanacore)
 find_package(ArborX REQUIRED)
 find_package(Boost 1.66.0 REQUIRED)
 
+if(Kokkos_VERSION_MAJOR LESS 4 AND Kokkos_VERSION_MINOR LESS 7)
+  message( FATAL_ERROR "Picasso requires Kokkos >= 3.7" )
+endif()
+
 if( NOT Cabana_ENABLE_CAJITA )
   message( FATAL_ERROR "Cabana must be compiled with Cajita enabled" )
 endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,7 +108,7 @@ RUN SILO_VERSION=4.10.2 && \
     cd ../../ && rm -r silo
 
 # Install Kokkos
-ARG KOKKOS_VERSION=3.4.01
+ARG KOKKOS_VERSION=3.7.01
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     KOKKOS_ARCHIVE=kokkos-${KOKKOS_VERSION}.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -116,7 +116,7 @@ RUN SILO_VERSION=4.10.2 && \
     cd ../../ && rm -r silo
 
 # Install Kokkos
-ARG KOKKOS_VERSION=3.4.01
+ARG KOKKOS_VERSION=3.7.01
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     KOKKOS_ARCHIVE=kokkos-${KOKKOS_HASH}.tar.gz && \

--- a/src/Picasso_APIC.hpp
+++ b/src/Picasso_APIC.hpp
@@ -19,7 +19,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <cmath>
 #include <type_traits>
 
 namespace Picasso

--- a/src/Picasso_BatchedLinearAlgebra.hpp
+++ b/src/Picasso_BatchedLinearAlgebra.hpp
@@ -14,7 +14,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <cmath>
 #include <functional>
 #include <type_traits>
 

--- a/src/Picasso_CurvilinearMesh.hpp
+++ b/src/Picasso_CurvilinearMesh.hpp
@@ -20,7 +20,6 @@
 #include <Kokkos_Core.hpp>
 
 #include <array>
-#include <cmath>
 #include <memory>
 #include <type_traits>
 

--- a/src/Picasso_FacetGeometry.hpp
+++ b/src/Picasso_FacetGeometry.hpp
@@ -157,20 +157,6 @@ class FacetGeometry
             dst[4] = fmax( dst[4], src[4] );
             dst[5] = fmax( dst[5], src[5] );
         }
-        // FIXME: remove when Kokkos 3.7 is required.
-#if KOKKOS_VERSION < 30700
-        KOKKOS_FUNCTION
-        void join( volatile value_type dst,
-                   const volatile value_type src ) const
-        {
-            dst[0] = fmin( dst[0], src[0] );
-            dst[1] = fmin( dst[1], src[1] );
-            dst[2] = fmin( dst[2], src[2] );
-            dst[3] = fmax( dst[3], src[3] );
-            dst[4] = fmax( dst[4], src[4] );
-            dst[5] = fmax( dst[5], src[5] );
-        }
-#endif
 
         KOKKOS_FUNCTION
         void init( value_type v ) const

--- a/src/Picasso_FacetGeometry.hpp
+++ b/src/Picasso_FacetGeometry.hpp
@@ -20,7 +20,6 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <cfloat>
-#include <cmath>
 #include <fstream>
 #include <unordered_map>
 #include <vector>
@@ -119,6 +118,9 @@ class FacetGeometry
         KOKKOS_FUNCTION
         void operator()( const size_type facet_id, value_type result ) const
         {
+            using Kokkos::fmax;
+            using Kokkos::fmin;
+
             auto f_start = ( volume_id == 0 ) ? 0 : offsets( volume_id - 1 );
             auto f = f_start + facet_id;
             result[0] =
@@ -150,12 +152,12 @@ class FacetGeometry
         KOKKOS_FUNCTION
         void join( value_type dst, const value_type src ) const
         {
-            dst[0] = fmin( dst[0], src[0] );
-            dst[1] = fmin( dst[1], src[1] );
-            dst[2] = fmin( dst[2], src[2] );
-            dst[3] = fmax( dst[3], src[3] );
-            dst[4] = fmax( dst[4], src[4] );
-            dst[5] = fmax( dst[5], src[5] );
+            dst[0] = Kokkos::fmin( dst[0], src[0] );
+            dst[1] = Kokkos::fmin( dst[1], src[1] );
+            dst[2] = Kokkos::fmin( dst[2], src[2] );
+            dst[3] = Kokkos::fmax( dst[3], src[3] );
+            dst[4] = Kokkos::fmax( dst[4], src[4] );
+            dst[5] = Kokkos::fmax( dst[5], src[5] );
         }
 
         KOKKOS_FUNCTION

--- a/src/Picasso_LevelSet.hpp
+++ b/src/Picasso_LevelSet.hpp
@@ -21,7 +21,6 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <cfloat>
-#include <cmath>
 
 //---------------------------------------------------------------------------//
 namespace Picasso
@@ -238,7 +237,7 @@ class LevelSet
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 // Only redistance on the fine grid if the estimate is less
                 // than the threshold distance.
-                if ( fabs( estimate_view( i, j, k, 0 ) ) < threshold )
+                if ( Kokkos::fabs( estimate_view( i, j, k, 0 ) ) < threshold )
                 {
                     int entity_index[3] = { i, j, k };
                     distance_view( i, j, k, 0 ) =

--- a/src/Picasso_LevelSetRedistance.hpp
+++ b/src/Picasso_LevelSetRedistance.hpp
@@ -19,7 +19,6 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
 
-#include <cmath>
 #include <limits>
 
 namespace Picasso
@@ -45,10 +44,11 @@ clampPointToLocalDomain( const LocalMeshType& local_mesh, const double dx,
 {
     for ( int d = 0; d < 3; ++d )
     {
-        x[d] =
-            fmin( local_mesh.highCorner( Cajita::Ghost(), d ) - 0.001 * dx,
-                  fmax( local_mesh.lowCorner( Cajita::Ghost(), d ) + 0.001 * dx,
-                        x[d] ) );
+        x[d] = Kokkos::fmin(
+            local_mesh.highCorner( Cajita::Ghost(), d ) - 0.001 * dx,
+            Kokkos::fmax( local_mesh.lowCorner( Cajita::Ghost(), d ) +
+                              0.001 * dx,
+                          x[d] ) );
     }
 }
 
@@ -162,7 +162,7 @@ globalMin( const SignedDistanceView& phi_0, const double sign,
             mag += ray[d] * ray[d];
         }
         mag = t_k *
-              ( 1 - exp( Kokkos::rand<RandState, double>::draw(
+              ( 1 - Kokkos::exp( Kokkos::rand<RandState, double>::draw(
                         rand_state, -4.0, 0.0 ) ) ) /
               sqrt( mag );
         for ( int d = 0; d < 3; ++d )
@@ -176,7 +176,7 @@ globalMin( const SignedDistanceView& phi_0, const double sign,
 
         // If less than the current value assign the results as the new
         // minimum.
-        if ( fabs( phi_trial ) < fabs( phi_min ) )
+        if ( Kokkos::fabs( phi_trial ) < Kokkos::fabs( phi_min ) )
         {
             phi_min = phi_trial;
             for ( int d = 0; d < 3; ++d )
@@ -256,7 +256,7 @@ redistanceEntity( EntityType, const SignedDistanceView& phi_0,
                          max_projection_iter, num_random, rng, sd, y );
 
     // Check for convergence.
-    if ( fabs( phi_new ) < dx * secant_tol )
+    if ( Kokkos::fabs( phi_new ) < dx * secant_tol )
         return sign * t_new;
 
     // Perform secant iterations to compute the signed distance. Stop when
@@ -270,7 +270,7 @@ redistanceEntity( EntityType, const SignedDistanceView& phi_0,
         // Clamp the step size if it exceeds the maximum step size. This
         // is needed to detect near division-by-zero resulting from a local
         // minimum.
-        if ( fabs( delta_t ) > delta_t_max )
+        if ( Kokkos::fabs( delta_t ) > delta_t_max )
         {
             delta_t = ( phi_new > 0.0 ) ? delta_t_max : -delta_t_max;
         }
@@ -285,7 +285,7 @@ redistanceEntity( EntityType, const SignedDistanceView& phi_0,
                              max_projection_iter, num_random, rng, sd, y );
 
         // Check for convergence.
-        if ( fabs( phi_new ) < dx * secant_tol )
+        if ( Kokkos::fabs( phi_new ) < dx * secant_tol )
         {
             break;
         }

--- a/src/Picasso_ParticleLevelSet.hpp
+++ b/src/Picasso_ParticleLevelSet.hpp
@@ -23,7 +23,6 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <cfloat>
-#include <cmath>
 
 //---------------------------------------------------------------------------//
 // ArborX Data

--- a/src/Picasso_PolyPIC.hpp
+++ b/src/Picasso_PolyPIC.hpp
@@ -19,7 +19,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <cmath>
 #include <type_traits>
 
 namespace Picasso

--- a/src/Picasso_UniformCartesianMeshMapping.hpp
+++ b/src/Picasso_UniformCartesianMeshMapping.hpp
@@ -23,7 +23,6 @@
 
 #include <mpi.h>
 
-#include <cmath>
 #include <limits>
 #include <type_traits>
 

--- a/src/Picasso_UniformMesh.hpp
+++ b/src/Picasso_UniformMesh.hpp
@@ -18,7 +18,6 @@
 
 #include <boost/property_tree/ptree.hpp>
 
-#include <cmath>
 #include <memory>
 
 #include <mpi.h>

--- a/unit_test/tstBatchedLinearAlgebra.hpp
+++ b/unit_test/tstBatchedLinearAlgebra.hpp
@@ -1267,14 +1267,11 @@ void quaternionTest()
 
 void quaMatRotTest()
 {
-    double pi = 4.0 * atan( 1.0 );
+    double pi = 4.0 * Kokkos::atan( 1.0 );
     double phi = pi / 2.0;
 
-    using Kokkos::Experimental::cos;
-    using Kokkos::Experimental::sin;
-
-    LinearAlgebra::Quaternion<double> q = { cos( phi / 2.0 ), 0.0, 0.0,
-                                            sin( phi / 2.0 ) };
+    LinearAlgebra::Quaternion<double> q = { Kokkos::cos( phi / 2.0 ), 0.0, 0.0,
+                                            Kokkos::sin( phi / 2.0 ) };
 
     // Convert the quaternion to its equivalent rotation matrix
     auto rot_mat = static_cast<Mat3<double>>( q );

--- a/unit_test/tstParticleLevelSet.hpp
+++ b/unit_test/tstParticleLevelSet.hpp
@@ -23,8 +23,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <cmath>
-
 #include <gtest/gtest.h>
 
 using namespace Picasso;
@@ -116,7 +114,7 @@ void zalesaksTest( const std::string& filename )
         0, time, *( level_set->levelSet()->getSignedDistance() ) );
 
     // Advect the disk one full rotation.
-    double pi = 4.0 * atan( 1.0 );
+    double pi = 4.0 * Kokkos::atan( 1.0 );
     int num_step = 1; // change to 628 to go one revolution.
     double delta_phi = 2.0 * pi / num_step;
     for ( int t = 0; t < num_step; ++t )
@@ -141,14 +139,15 @@ void zalesaksTest( const std::string& filename )
                 double r = sqrt( x * x + y * y );
 
                 // Compute the angle relative to the origin.
-                double phi = ( y >= 0.0 ) ? acos( x / r ) : -acos( x / r );
+                double phi = ( y >= 0.0 ) ? Kokkos::acos( x / r )
+                                          : -Kokkos::acos( x / r );
 
                 // Increment the angle.
                 phi += delta_phi;
 
                 // Compute new particle location.
-                x = r * cos( phi ) + 0.5;
-                y = r * sin( phi ) + 0.5;
+                x = r * Kokkos::cos( phi ) + 0.5;
+                y = r * Kokkos::sin( phi ) + 0.5;
 
                 // Update.
                 xp( p, Dim::I ) = x;


### PR DESCRIPTION
Fixup for #85 (namespace changes in different Kokkos versions)