### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
             cmake_build_type: 'Debug'
             kokkos_ver: '4.1.00'
             coverage: 'ON'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:
       - name: Get trail license

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -16,7 +16,7 @@ jobs:
         distro: ['ubuntu:latest']
         openmp: ['ON', 'OFF']
         cmake_build_type: ['Debug']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:
       - name: Checkout kokkos


### PR DESCRIPTION
20.04 is being retired; avoid having to do this in the future with latest
