### PR TITLE
Fix Cabana::Grid::createLocalMesh memory space

### DIFF
--- a/unit_test/tstAPIC.hpp
+++ b/unit_test/tstAPIC.hpp
@@ -551,7 +551,7 @@ void collocatedTest()
     UniformMesh<TEST_MEMSPACE> mesh( inputs, global_box, minimum_halo_size,
                                      MPI_COMM_WORLD );
     auto local_mesh =
-        Cabana::Grid::createLocalMesh<TEST_EXECSPACE>( *( mesh.localGrid() ) );
+        Cabana::Grid::createLocalMesh<TEST_MEMSPACE>( *( mesh.localGrid() ) );
 
     // Particle mass.
     double pm = 0.134;
@@ -723,7 +723,7 @@ void staggeredTest()
     UniformMesh<TEST_MEMSPACE> mesh( inputs, global_box, minimum_halo_size,
                                      MPI_COMM_WORLD );
     auto local_mesh =
-        Cabana::Grid::createLocalMesh<TEST_EXECSPACE>( *( mesh.localGrid() ) );
+        Cabana::Grid::createLocalMesh<TEST_MEMSPACE>( *( mesh.localGrid() ) );
 
     // Particle mass.
     double pm = 0.134;

--- a/unit_test/tstAdaptiveMesh.hpp
+++ b/unit_test/tstAdaptiveMesh.hpp
@@ -74,7 +74,7 @@ void constructionTest()
         Kokkos::HostSpace(), nodes_1->view() );
     auto local_space_1 = nodes_1->layout()->localGrid()->indexSpace(
         Cabana::Grid::Ghost(), Cabana::Grid::Node(), Cabana::Grid::Local() );
-    auto local_mesh_1 = Cabana::Grid::createLocalMesh<TEST_EXECSPACE>(
+    auto local_mesh_1 = Cabana::Grid::createLocalMesh<TEST_MEMSPACE>(
         *( nodes_1->layout()->localGrid() ) );
     for ( int i = local_space_1.min( 0 ); i < local_space_1.max( 0 ); ++i )
         for ( int j = local_space_1.min( 1 ); j < local_space_1.max( 1 ); ++j )
@@ -130,7 +130,7 @@ void constructionTest()
         Kokkos::HostSpace(), nodes_2->view() );
     auto local_space_2 = nodes_2->layout()->localGrid()->indexSpace(
         Cabana::Grid::Ghost(), Cabana::Grid::Node(), Cabana::Grid::Local() );
-    auto local_mesh_2 = Cabana::Grid::createLocalMesh<TEST_EXECSPACE>(
+    auto local_mesh_2 = Cabana::Grid::createLocalMesh<TEST_MEMSPACE>(
         *( nodes_2->layout()->localGrid() ) );
     for ( int i = local_space_2.min( 0 ); i < local_space_2.max( 0 ); ++i )
         for ( int j = local_space_2.min( 1 ); j < local_space_2.max( 1 ); ++j )

--- a/unit_test/tstFieldManager.hpp
+++ b/unit_test/tstFieldManager.hpp
@@ -176,7 +176,7 @@ void adaptiveTest()
         fm.array( FieldLocation::Node(), Field::PhysicalPosition<3>() );
     auto host_coords = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
                                                             nodes->view() );
-    auto local_mesh = Cabana::Grid::createLocalMesh<TEST_EXECSPACE>(
+    auto local_mesh = Cabana::Grid::createLocalMesh<TEST_MEMSPACE>(
         *( nodes->layout()->localGrid() ) );
     auto local_space = nodes->layout()->localGrid()->indexSpace(
         Cabana::Grid::Ghost(), Cabana::Grid::Node(), Cabana::Grid::Local() );

--- a/unit_test/tstPolyPIC.hpp
+++ b/unit_test/tstPolyPIC.hpp
@@ -207,7 +207,7 @@ void collocatedTest()
     UniformMesh<TEST_MEMSPACE> mesh( inputs, global_box, minimum_halo_size,
                                      MPI_COMM_WORLD );
     auto local_mesh =
-        Cabana::Grid::createLocalMesh<TEST_EXECSPACE>( *( mesh.localGrid() ) );
+        Cabana::Grid::createLocalMesh<TEST_MEMSPACE>( *( mesh.localGrid() ) );
 
     // Time step size.
     double dt = 0.0001;
@@ -376,7 +376,7 @@ void staggeredTest()
     UniformMesh<TEST_MEMSPACE> mesh( inputs, global_box, minimum_halo_size,
                                      MPI_COMM_WORLD );
     auto local_mesh =
-        Cabana::Grid::createLocalMesh<TEST_EXECSPACE>( *( mesh.localGrid() ) );
+        Cabana::Grid::createLocalMesh<TEST_MEMSPACE>( *( mesh.localGrid() ) );
 
     // Time step size.
     double dt = 0.0001;

--- a/unit_test/tstUniformMesh.hpp
+++ b/unit_test/tstUniformMesh.hpp
@@ -110,7 +110,7 @@ void constructionTest()
         Kokkos::HostSpace(), nodes_2->view() );
     auto local_space_2 = nodes_2->layout()->localGrid()->indexSpace(
         Cabana::Grid::Ghost(), Cabana::Grid::Node(), Cabana::Grid::Local() );
-    auto local_mesh_2 = Cabana::Grid::createLocalMesh<TEST_EXECSPACE>(
+    auto local_mesh_2 = Cabana::Grid::createLocalMesh<TEST_MEMSPACE>(
         *( nodes_2->layout()->localGrid() ) );
     for ( int i = local_space_2.min( 0 ); i < local_space_2.max( 0 ); ++i )
         for ( int j = local_space_2.min( 1 ); j < local_space_2.max( 1 ); ++j )


### PR DESCRIPTION
Based on update of Cabana, use memory space for Cabana::Grid::createLocalMesh